### PR TITLE
fix(map): prevent Prime borders masking rooms

### DIFF
--- a/custom_components/roomba_plus/image.py
+++ b/custom_components/roomba_plus/image.py
@@ -3079,12 +3079,23 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         if self._renderer is None:
             self._renderer = MapRenderer(RendererConfig(), None, None)
 
-        # Seed the auto-fit transform from the room extents. Classic gets
-        # this from accumulated poses; Prime has the polygons up front,
-        # which is why its map is complete before the first mission.
-        for ring in self._polygons.values():
-            for x_mm, y_mm in ring:
-                self._renderer.add_pose(x_mm, y_mm, 0.0)
+        # Polygon vertices are static geometry, not consecutive robot poses.
+        # Seed the fit directly so the telemetry jump filter cannot discard
+        # corners more than 500 mm apart.
+        rings = [
+            *self._polygons.values(),
+            *self._floor_plan.carpet,
+            *self._floor_plan.borders,
+        ]
+        self._renderer._points = [  # noqa: SLF001
+            self._renderer._mm_to_px(x, y)  # noqa: SLF001
+            for ring in rings
+            for x, y in ring
+        ]
+        _, _, _, fit_scale, fit_cx, fit_cy = self._renderer._compute_fit()  # noqa: SLF001
+        self._renderer._fit_scale = fit_scale  # noqa: SLF001
+        self._renderer._fit_cx = fit_cx  # noqa: SLF001
+        self._renderer._fit_cy = fit_cy  # noqa: SLF001
 
         size = self._renderer._cfg.size_px  # noqa: SLF001
         img = Image.new("RGB", (size, size), (30, 30, 30))
@@ -3112,7 +3123,13 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
             draw.polygon([to_px(x, y) for x, y in ring], outline=(150, 120, 80))
 
         for ring in self._floor_plan.borders:
-            draw.polygon([to_px(x, y) for x, y in ring], fill=(90, 90, 90))
+            # _rings_mm keeps outer rings only. Filling one would erase its
+            # interior holes and mask every room and live layer beneath it.
+            draw.polygon(
+                [to_px(x, y) for x, y in ring],
+                outline=(90, 90, 90),
+                width=2,
+            )
 
         # THE TRAIL, on top of the floor plan and under the labels.
         #
@@ -3275,4 +3292,3 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
             self.async_write_ha_state()
         except Exception:  # noqa: BLE001
             _LOGGER.debug("Prime rooms map: live re-render failed", exc_info=True)
-

--- a/tests/test_prime_room_map.py
+++ b/tests/test_prime_room_map.py
@@ -591,6 +591,53 @@ class TestFloorPlanFromTheMapBundle:
         assert plan.borders == [] and plan.carpet == [] and plan.dock is None
 
 
+class TestPrimeRoomsRendering:
+    @staticmethod
+    def _entity(room, border):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from custom_components.roomba_plus.image import PrimeRoomsImage
+
+        entity = object.__new__(PrimeRoomsImage)
+        entity._renderer = None
+        entity._polygons = {"1": room}
+        entity._names = {"1": "Room"}
+        entity._floor_plan = SimpleNamespace(
+            borders=[border] if border else [], carpet=[], dock=None
+        )
+        entity._config_entry = MagicMock(
+            options={}, runtime_data=MagicMock(prime_positions=[])
+        )
+        return entity
+
+    def test_border_does_not_mask_room_fill(self):
+        """A border outer ring must not become a solid grey floor mask."""
+        import io
+
+        from PIL import Image
+
+        from custom_components.roomba_plus.image import ROOM_FILL_PALETTE
+
+        room = [(-1000, -1000), (1000, -1000), (1000, 1000), (-1000, 1000)]
+        border = [(-5000, -5000), (5000, -5000), (5000, 5000), (-5000, 5000)]
+        entity = self._entity(room, border)
+
+        image = Image.open(io.BytesIO(entity._render_png())).convert("RGB")
+
+        assert image.getpixel((300, 300)) == ROOM_FILL_PALETTE[0]
+
+    def test_all_polygon_vertices_drive_auto_fit(self):
+        """Static geometry bypasses the 500 mm robot-pose jump filter."""
+        room = [(-5000, -5000), (5000, -5000), (5000, 5000), (-5000, 5000)]
+        entity = self._entity(room, [])
+
+        entity._render_png()
+
+        assert len(entity._renderer._points) == len(room)
+        assert entity._renderer._fit_scale > entity._renderer._cfg.scale
+
+
 class TestRoomLabelOption:
     """Labels in the image are OFF by default, and that reads backwards
     until you know what Classic does.


### PR DESCRIPTION
## Summary

- Fit Prime room maps using all static room, carpet, and border geometry instead of treating polygon vertices as robot poses.
- Render floor-plan borders as outlines so they do not mask room fills or live map layers.
- Add regression tests for border visibility and auto-fit behavior.

## Testing

- Added coverage in `tests/test_prime_room_map.py` for border rendering and polygon-driven fitting.

## Screenshots

Before

<img width="1165" height="906" alt="image" src="https://github.com/user-attachments/assets/73801735-e1e0-4a3a-9c67-64c3db75b34c" />

After

<img width="1056" height="803" alt="image" src="https://github.com/user-attachments/assets/5332b846-a4e9-4253-a5b9-4a0dae0604b7" />
