### PR TITLE
fix(map): restore live Prime room-map layers

### DIFF
--- a/custom_components/roomba_plus/image.py
+++ b/custom_components/roomba_plus/image.py
@@ -3009,11 +3009,9 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         current = await backend._current_map_id()  # noqa: SLF001
         p2map_id = current if current in map_ids else map_ids[0]
 
-        (
-            self._polygons,
-            self._names,
-            self._preferences,
-        ) = await async_build_prime_room_polygons(self._config_entry, p2map_id)
+        polygons, names, preferences = await async_build_prime_room_polygons(
+            self._config_entry, p2map_id
+        )
 
 
         # The floor plan is a SECOND cloud call, and a failure costs only
@@ -3036,7 +3034,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         except Exception:  # noqa: BLE001
             _LOGGER.debug("Prime map: could not read map versions", exc_info=True)
 
-        self._floor_plan = (
+        floor_plan = (
             await async_build_prime_floor_plan(self._config_entry, p2map_id, version)
             if version
             else PrimeFloorPlan(
@@ -3055,9 +3053,9 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # three accounts, and the bundle layer is not guaranteed to
         # exist. Only a name actually present in the bundle replaces one,
         # so a robot without that layer is unaffected.
-        for room_id, name in (self._floor_plan.room_names or {}).items():
-            if room_id in self._names:
-                self._names[room_id] = name
+        for room_id, name in (floor_plan.room_names or {}).items():
+            if room_id in names:
+                names[room_id] = name
 
         # OUTLINES FROM THE BUNDLE, where the metadata has none.
         #
@@ -3072,12 +3070,25 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # Metadata geometry still wins where it exists: it is what this
         # entity was built on and is confirmed working elsewhere. The
         # bundle fills the gap rather than replacing the source.
-        for room_id, ring in (self._floor_plan.room_polygons or {}).items():
-            self._polygons.setdefault(room_id, ring)
-            self._names.setdefault(
+        for room_id, ring in (floor_plan.room_polygons or {}).items():
+            polygons.setdefault(room_id, ring)
+            names.setdefault(
                 room_id,
-                (self._floor_plan.room_names or {}).get(room_id) or f"Room {room_id}",
+                (floor_plan.room_names or {}).get(room_id) or f"Room {room_id}",
             )
+        if not polygons:
+            # A post-mission shadow can announce a new map version before
+            # its bundle is available. Do not turn a working map unavailable
+            # just because this transient refresh has no geometry.
+            _LOGGER.debug(
+                "Prime rooms map: refresh returned no geometry; keeping cached map"
+            )
+            return
+
+        self._polygons = polygons
+        self._names = names
+        self._preferences = preferences
+        self._floor_plan = floor_plan
         if self._polygons:
             self._png = await self.hass.async_add_executor_job(self._render_png)
             self._attr_image_last_updated = dt_util.now(datetime.timezone.utc)

--- a/custom_components/roomba_plus/image.py
+++ b/custom_components/roomba_plus/image.py
@@ -437,7 +437,7 @@ class PrimeMapImage(IRobotEntity, ImageEntity):
         renderer already drops jumps over 500 mm as noise, which is what
         keeps a relocalisation from drawing a line across the room.
         """
-        from .prime_room_map import _METRES_TO_MM  # noqa: PLC0415
+        from .prime_room_map import METRES_TO_MM  # noqa: PLC0415
 
         # COLLECTED, NOT DRAWN HERE. This entity shows iRobot's own
         # rendered PNG and has no renderer of its own; the trail belongs
@@ -455,8 +455,8 @@ class PrimeMapImage(IRobotEntity, ImageEntity):
                     continue
                 orientation_rad = getattr(sample, "orientation", None) or 0.0
                 data.prime_positions.append((
-                    float(x_m) * _METRES_TO_MM,
-                    float(y_m) * _METRES_TO_MM,
+                    float(x_m) * METRES_TO_MM,
+                    float(y_m) * METRES_TO_MM,
                     math.degrees(float(orientation_rad)),
                 ))
             # Bounded. A mission produced 904 points on one tester's
@@ -3098,7 +3098,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         from PIL import Image, ImageDraw  # noqa: PLC0415
 
         from .map_renderer import MapRenderer, RendererConfig  # noqa: PLC0415
-        from .prime_room_map import _rings_mm  # noqa: PLC0415
+        from .prime_room_map import METRES_TO_MM, rings_mm  # noqa: PLC0415
 
         if self._renderer is None:
             self._renderer = MapRenderer(RendererConfig(), None, None)
@@ -3127,7 +3127,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
 
         to_px = self._renderer._mm_to_px_fit  # noqa: SLF001
         live_bundle = self._live_bundle or {}
-        live_coverage = _rings_mm(live_bundle.get("coverage"))
+        live_coverage = rings_mm(live_bundle.get("coverage"))
 
         # LAYER ORDER MATTERS, bottom to top: rooms, then carpet, then
         # walls, then the dock, then labels.
@@ -3171,7 +3171,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
             coords = (feature.get("geometry") or {}).get("coordinates")
             try:
                 points = [
-                    to_px(float(x) * 1000.0, float(y) * 1000.0)
+                    to_px(float(x) * METRES_TO_MM, float(y) * METRES_TO_MM)
                     for x, y in coords
                 ]
             except (TypeError, ValueError):
@@ -3182,7 +3182,10 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         for feature in (live_bundle.get("hazard") or {}).get("features") or []:
             coords = (feature.get("geometry") or {}).get("coordinates")
             try:
-                px, py = to_px(float(coords[0]) * 1000.0, float(coords[1]) * 1000.0)
+                px, py = to_px(
+                    float(coords[0]) * METRES_TO_MM,
+                    float(coords[1]) * METRES_TO_MM,
+                )
             except (TypeError, ValueError, IndexError):
                 continue
             draw.regular_polygon((px, py, 8), 3, fill=(240, 150, 60))

--- a/custom_components/roomba_plus/image.py
+++ b/custom_components/roomba_plus/image.py
@@ -82,7 +82,8 @@ _LOGGER = logging.getLogger(__name__)
 #: not for the normal case.
 _MAX_PRIME_POSITIONS = 5000
 
-#: Dispatcher signal carrying a freshly parsed live map bundle.
+#: Dispatcher signal carrying a freshly parsed live map bundle, or a
+#: position-only invalidation.
 #:
 #: The two Prime image entities are split by what they can do: one
 #: watches the map stream and shows iRobot's rendered PNG, the other
@@ -584,6 +585,17 @@ class PrimeMapImage(IRobotEntity, ImageEntity):
                             stats.get("position_points", 0) + len(message.updates)
                         )
                         self._feed_trail(message)
+                        # Position packets arrive independently of map bundles.
+                        # Re-render the sibling Rooms Map now, otherwise its
+                        # trail remains stale until a later bundle happens to
+                        # arrive. None preserves the most recent bundle.
+                        async_dispatcher_send(
+                            self.hass,
+                            _SIGNAL_PRIME_LIVE_BUNDLE.format(
+                                self._config_entry.entry_id
+                            ),
+                            None,
+                        )
                         continue
 
                     if not isinstance(message, MapUpdateMessage) or not message.livemap_url_raw:
@@ -3075,6 +3087,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         from PIL import Image, ImageDraw  # noqa: PLC0415
 
         from .map_renderer import MapRenderer, RendererConfig  # noqa: PLC0415
+        from .prime_room_map import _rings_mm  # noqa: PLC0415
 
         if self._renderer is None:
             self._renderer = MapRenderer(RendererConfig(), None, None)
@@ -3102,6 +3115,8 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         draw = ImageDraw.Draw(img)
 
         to_px = self._renderer._mm_to_px_fit  # noqa: SLF001
+        live_bundle = self._live_bundle or {}
+        live_coverage = _rings_mm(live_bundle.get("coverage"))
 
         # LAYER ORDER MATTERS, bottom to top: rooms, then carpet, then
         # walls, then the dock, then labels.
@@ -3122,6 +3137,12 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
             # per-room colours that keep adjacent rooms distinguishable.
             draw.polygon([to_px(x, y) for x, y in ring], outline=(150, 120, 80))
 
+        # The live bundle is the data the app uses for cleaned coverage,
+        # trajectories and hazards. Keep the static-map fit: these layers
+        # share its coordinate frame and must not move the room layout.
+        for ring in live_coverage:
+            draw.polygon([to_px(x, y) for x, y in ring], fill=(120, 190, 145))
+
         for ring in self._floor_plan.borders:
             # OUTLINE ONLY, for the reason written two lines above about
             # carpet and then not applied here.
@@ -3134,6 +3155,26 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
             # The wall is the outline. Drawing it as one shows the same
             # geometry without covering anything.
             draw.polygon([to_px(x, y) for x, y in ring], outline=(90, 90, 90))
+
+        for feature in (live_bundle.get("trajectories") or {}).get("features") or []:
+            coords = (feature.get("geometry") or {}).get("coordinates")
+            try:
+                points = [
+                    to_px(float(x) * 1000.0, float(y) * 1000.0)
+                    for x, y in coords
+                ]
+            except (TypeError, ValueError):
+                continue
+            if len(points) >= 2:
+                draw.line(points, fill=(80, 150, 235), width=2)
+
+        for feature in (live_bundle.get("hazard") or {}).get("features") or []:
+            coords = (feature.get("geometry") or {}).get("coordinates")
+            try:
+                px, py = to_px(float(coords[0]) * 1000.0, float(coords[1]) * 1000.0)
+            except (TypeError, ValueError, IndexError):
+                continue
+            draw.regular_polygon((px, py, 8), 3, fill=(240, 150, 60))
 
         # THE TRAIL, on top of the floor plan and under the labels.
         #
@@ -3168,6 +3209,16 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
                 previous = (x_mm, y_mm)
             if len(trail) >= 2:
                 draw.line(trail, fill=(120, 200, 255), width=2)
+
+        if positions:
+            x_mm, y_mm, heading = positions[-1]
+            px, py = to_px(x_mm, y_mm)
+            draw.ellipse((px - 6, py - 6, px + 6, py + 6), fill=(60, 170, 255))
+            radians = math.radians(heading)
+            draw.line(
+                (px, py, px + math.cos(radians) * 12, py - math.sin(radians) * 12),
+                fill=(255, 255, 255), width=2,
+            )
 
         if self._floor_plan.dock is not None:
             dx, dy, _orientation = self._floor_plan.dock
@@ -3265,7 +3316,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         return attrs
 
     @callback
-    def _on_live_bundle(self, bundle: Any) -> None:
+    def _on_live_bundle(self, bundle: Any | None) -> None:
         """Redraws the rooms map when a live bundle arrives.
 
         THE MAP NOW UPDATES DURING A MISSION rather than only when the
@@ -3281,7 +3332,8 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         callback: rendering a PNG inline blocks the event loop for as
         long as PIL takes.
         """
-        self._live_bundle = bundle
+        if bundle is not None:
+            self._live_bundle = bundle
         if not self._polygons:
             return
         self._config_entry.async_create_background_task(
@@ -3296,4 +3348,3 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
             self.async_write_ha_state()
         except Exception:  # noqa: BLE001
             _LOGGER.debug("Prime rooms map: live re-render failed", exc_info=True)
-

--- a/custom_components/roomba_plus/image.py
+++ b/custom_components/roomba_plus/image.py
@@ -82,8 +82,7 @@ _LOGGER = logging.getLogger(__name__)
 #: not for the normal case.
 _MAX_PRIME_POSITIONS = 5000
 
-#: Dispatcher signal carrying a freshly parsed live map bundle, or a
-#: position-only invalidation.
+#: Dispatcher signals for the two independent live-map message shapes.
 #:
 #: The two Prime image entities are split by what they can do: one
 #: watches the map stream and shows iRobot's rendered PNG, the other
@@ -95,6 +94,8 @@ _MAX_PRIME_POSITIONS = 5000
 #: and that it returns a full map bundle rather than the raw occupancy
 #: grid. We had been consuming only the raw one.
 _SIGNAL_PRIME_LIVE_BUNDLE = "roomba_plus_prime_live_bundle_{}"
+_SIGNAL_PRIME_LIVE_POSITION = "roomba_plus_prime_live_position_{}"
+_LIVE_MAP_STATE_UPDATE_INTERVAL = 2.0
 PARALLEL_UPDATES = 0
 
 # ROOM-PALETTE (v2.9.0) — rotating per-room fill colours for _render_rooms_png().
@@ -585,16 +586,13 @@ class PrimeMapImage(IRobotEntity, ImageEntity):
                             stats.get("position_points", 0) + len(message.updates)
                         )
                         self._feed_trail(message)
-                        # Position packets arrive independently of map bundles.
-                        # Re-render the sibling Rooms Map now, otherwise its
-                        # trail remains stale until a later bundle happens to
-                        # arrive. None preserves the most recent bundle.
+                        # Position packets carry no bundle. The Rooms Map
+                        # already reads positions from runtime_data.
                         async_dispatcher_send(
                             self.hass,
-                            _SIGNAL_PRIME_LIVE_BUNDLE.format(
+                            _SIGNAL_PRIME_LIVE_POSITION.format(
                                 self._config_entry.entry_id
-                            ),
-                            None,
+                            )
                         )
                         continue
 
@@ -2936,6 +2934,8 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         self._preferences: dict[str, Any] = {}
         self._renderer: Any = None
         self._png: bytes | None = None
+        self._live_dirty = False
+        self._last_live_state_write = 0.0
 
     @property
     def suggested_object_id(self) -> str:
@@ -2966,6 +2966,13 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
                 self.hass,
                 _SIGNAL_PRIME_LIVE_BUNDLE.format(self._config_entry.entry_id),
                 self._on_live_bundle,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                _SIGNAL_PRIME_LIVE_POSITION.format(self._config_entry.entry_id),
+                self._on_live_position,
             )
         )
 
@@ -3275,6 +3282,9 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         map change is picked up without a subscription.
         """
         await self._async_refresh_if_map_changed()
+        if self._live_dirty and self._polygons:
+            self._png = await self.hass.async_add_executor_job(self._render_png)
+            self._live_dirty = False
         return self._png
 
     async def _async_refresh_if_map_changed(self) -> None:
@@ -3330,35 +3340,38 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         return attrs
 
     @callback
-    def _on_live_bundle(self, bundle: Any | None) -> None:
-        """Redraws the rooms map when a live bundle arrives.
+    def _on_live_bundle(self, bundle: Any) -> None:
+        """Marks the Rooms Map dirty when a new live bundle arrives.
 
         THE MAP NOW UPDATES DURING A MISSION rather than only when the
         map version changes. Contributed by @jouwdan (PR #63), who found
         the second url on MapUpdateMessage.
 
-        Only redraws once room polygons exist -- before that there is
-        nothing to draw on, and a render would produce an empty image
-        that looks like a fault rather than like a robot that has not
-        mapped yet.
+        If room geometry has not arrived yet, the initial room refresh renders
+        the already-cached live data. This avoids a blank entity while the
+        static map is loading.
 
-        The work goes to a background task because this is a dispatcher
-        callback: rendering a PNG inline blocks the event loop for as
-        long as PIL takes.
+        Rendering happens only when Home Assistant fetches the image.
+        This keeps an idle dashboard from consuming CPU for updates it
+        will never display.
         """
-        if bundle is not None:
-            self._live_bundle = bundle
-        if not self._polygons:
-            return
-        self._config_entry.async_create_background_task(
-            self.hass, self._async_render_live_bundle(), "roomba_plus_live_bundle"
-        )
+        self._live_bundle = bundle
+        self._mark_live_dirty()
 
-    async def _async_render_live_bundle(self) -> None:
-        """Re-renders and publishes, off the event loop."""
-        try:
-            self._png = await self.hass.async_add_executor_job(self._render_png)
+    @callback
+    def _on_live_position(self) -> None:
+        """Marks the Rooms Map dirty when a live position arrives."""
+        self._mark_live_dirty()
+
+    @callback
+    def _mark_live_dirty(self) -> None:
+        """Advertise new live data at a bounded frontend update rate."""
+        self._live_dirty = True
+        now = _time_mod.monotonic()
+        if (
+            now - getattr(self, "_last_live_state_write", 0.0)
+            >= _LIVE_MAP_STATE_UPDATE_INTERVAL
+        ):
+            self._last_live_state_write = now
             self._attr_image_last_updated = dt_util.utcnow()
             self.async_write_ha_state()
-        except Exception:  # noqa: BLE001
-            _LOGGER.debug("Prime rooms map: live re-render failed", exc_info=True)

--- a/custom_components/roomba_plus/prime_room_map.py
+++ b/custom_components/roomba_plus/prime_room_map.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 #: Prime coordinates are metres, the renderer works in millimetres.
-_METRES_TO_MM = 1000.0
+METRES_TO_MM = 1000.0
 
 
 def _ring_mm(geometry: Any) -> list[tuple[float, float]]:
@@ -54,7 +54,7 @@ def _ring_mm(geometry: Any) -> list[tuple[float, float]]:
         return []
     try:
         ring = [
-            (float(x) * _METRES_TO_MM, float(y) * _METRES_TO_MM)
+            (float(x) * METRES_TO_MM, float(y) * METRES_TO_MM)
             for x, y in coords[0]
         ]
     except (TypeError, ValueError, IndexError):
@@ -302,13 +302,13 @@ def _room_polygons_from_bundle(
         )
         if room_id is None:
             continue
-        rings = _rings_mm({"features": [feature]})
+        rings = rings_mm({"features": [feature]})
         if rings:
             polygons[str(room_id)] = rings[0]
     return polygons
 
 
-def _rings_mm(features: Any) -> list[list[tuple[float, float]]]:
+def rings_mm(features: Any) -> list[list[tuple[float, float]]]:
     """Every outer ring in a GeoJSON FeatureCollection, in millimetres.
 
     Handles Polygon and MultiPolygon in one pass, because borders use the
@@ -339,7 +339,7 @@ def _rings_mm(features: Any) -> list[list[tuple[float, float]]]:
                 continue
             try:
                 ring = [
-                    (float(x) * _METRES_TO_MM, float(y) * _METRES_TO_MM)
+                    (float(x) * METRES_TO_MM, float(y) * METRES_TO_MM)
                     for x, y in polygon[0]
                 ]
             except (TypeError, ValueError, IndexError):
@@ -366,7 +366,7 @@ def _carpet_rings_mm(features: Any) -> list[list[tuple[float, float]]]:
     for feature in (features or {}).get("features") or []:
         if (feature.get("properties") or {}).get("type") != "carpet":
             continue
-        carpet.extend(_rings_mm({"features": [feature]}))
+        carpet.extend(rings_mm({"features": [feature]}))
     return carpet
 
 
@@ -382,8 +382,8 @@ def _dock_from(features: Any) -> tuple[float, float, float] | None:
             continue
         orientation = (feature.get("properties") or {}).get("orientation")
         return (
-            x * _METRES_TO_MM,
-            y * _METRES_TO_MM,
+            x * METRES_TO_MM,
+            y * METRES_TO_MM,
             float(orientation) if orientation is not None else 0.0,
         )
     return None
@@ -427,7 +427,7 @@ async def async_build_prime_floor_plan(
     plan = PrimeFloorPlan(
         room_names=_room_names_from_bundle(parsed.get("rooms")),
         room_polygons=_room_polygons_from_bundle(parsed.get("rooms")),
-        borders=_rings_mm(parsed.get("borders")),
+        borders=rings_mm(parsed.get("borders")),
         carpet=_carpet_rings_mm(parsed.get("floorTypes")),
         dock=_dock_from(parsed.get("dockPose")),
     )

--- a/tests/test_prime_room_map.py
+++ b/tests/test_prime_room_map.py
@@ -335,6 +335,38 @@ class TestTheRoomMapIsRefreshedOnlyWhenItChanges:
 
         assert "async_add_listener" not in source
 
+    @pytest.mark.asyncio
+    async def test_empty_post_mission_refresh_keeps_the_last_map(self):
+        """Max 705 metadata has no geometry, so a transient bundle miss
+        must not make an already rendered Rooms Map unavailable."""
+        from unittest.mock import patch
+
+        from custom_components.roomba_plus.image import PrimeRoomsImage
+        entity = object.__new__(PrimeRoomsImage)
+        entity.hass = MagicMock()
+        entity._polygons = {"room": [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]}
+        entity._names = {"room": "Kitchen"}
+        entity._preferences = {"room": {"profile": "normal"}}
+        entity._floor_plan = SimpleNamespace(borders=[[(0.0, 0.0)]])
+        entity._config_entry = MagicMock()
+        entity._config_entry.runtime_data.prime_robot.get_active_map_versions = AsyncMock(
+            return_value=[]
+        )
+        backend = MagicMock()
+        backend._all_map_ids = AsyncMock(return_value=["MAP-1"])
+        backend._current_map_id = AsyncMock(return_value="MAP-1")
+
+        with patch(
+            "custom_components.roomba_plus.room_cleaning.async_get_room_cleaning_backend",
+            return_value=backend,
+        ), patch(
+            "custom_components.roomba_plus.prime_room_map.async_build_prime_room_polygons",
+            new=AsyncMock(return_value=({}, {}, {})),
+        ):
+            await entity._async_refresh_rooms()
+
+        assert entity._polygons == {"room": [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]}
+
 
 class TestRoomsWithoutNames:
     """Two real captures disagree about whether rooms_metadata carries a

--- a/tests/test_prime_room_map.py
+++ b/tests/test_prime_room_map.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1086,6 +1087,46 @@ class TestLiveBundleUpdatesTheRoomsMap:
         source = inspect.getsource(PrimeRoomsImage._async_render_live_bundle)
 
         assert "async_add_executor_job" in source
+
+    def test_live_coverage_is_rendered_without_changing_the_room_fit(self):
+        """The live bundle is a layer, not a second coordinate system."""
+        import io
+
+        from PIL import Image
+
+        from custom_components.roomba_plus.image import PrimeRoomsImage
+
+        entity = object.__new__(PrimeRoomsImage)
+        entity._renderer = None
+        entity._polygons = {
+            "room": [
+                (0.0, 0.0),
+                (2000.0, 0.0),
+                (2000.0, 2000.0),
+                (0.0, 2000.0),
+            ]
+        }
+        entity._floor_plan = SimpleNamespace(carpet=[], borders=[], dock=None)
+        entity._live_bundle = {
+            "coverage": {
+                "features": [{
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5]]
+                        ],
+                    }
+                }]
+            }
+        }
+        entity._config_entry = SimpleNamespace(
+            runtime_data=SimpleNamespace(prime_positions=[]), options={}
+        )
+
+        image = Image.open(io.BytesIO(entity._render_png())).convert("RGB")
+        px, py = entity._renderer._mm_to_px_fit(1000.0, 1000.0)  # noqa: SLF001
+
+        assert image.getpixel((round(px), round(py))) == (120, 190, 145)
 
 
 class TestPolygonVerticesAreNotPoses:

--- a/tests/test_prime_room_map.py
+++ b/tests/test_prime_room_map.py
@@ -1081,6 +1081,7 @@ class TestLiveBundleUpdatesTheRoomsMap:
 
         assert "async_dispatcher_connect" in source
         assert "_on_live_bundle" in source
+        assert "_on_live_position" in source
 
     def test_the_subscription_is_removed_on_unload(self):
         """A reload would otherwise leave one connection per cycle, each
@@ -1093,21 +1094,21 @@ class TestLiveBundleUpdatesTheRoomsMap:
 
         assert "async_on_remove" in source
 
-    def test_nothing_is_rendered_before_rooms_exist(self):
-        """A render with no polygons produces an empty image, which looks
-        like a fault rather than like a robot that has not mapped yet."""
+    def test_live_updates_mark_the_image_dirty_without_rendering(self):
+        """The dispatcher path must not spend CPU when nobody is viewing."""
         from unittest.mock import MagicMock
 
         from custom_components.roomba_plus.image import PrimeRoomsImage
 
         entity = object.__new__(PrimeRoomsImage)
-        entity._polygons = {}
-        entity._config_entry = MagicMock()
-        entity.hass = MagicMock()
+        entity._live_dirty = False
+        entity._last_live_state_write = float("inf")
+        entity.async_write_ha_state = MagicMock()
 
         entity._on_live_bundle(MagicMock())
 
-        entity._config_entry.async_create_background_task.assert_not_called()
+        assert entity._live_dirty
+        entity.async_write_ha_state.assert_not_called()
 
     def test_rendering_happens_off_the_event_loop(self):
         """This is a dispatcher callback. Rendering a PNG inline would
@@ -1116,9 +1117,28 @@ class TestLiveBundleUpdatesTheRoomsMap:
 
         from custom_components.roomba_plus.image import PrimeRoomsImage
 
-        source = inspect.getsource(PrimeRoomsImage._async_render_live_bundle)
+        source = inspect.getsource(PrimeRoomsImage.async_image)
 
         assert "async_add_executor_job" in source
+
+    def test_live_state_updates_are_throttled(self):
+        """A dashboard should not refetch the image for every pose packet."""
+        from unittest.mock import MagicMock, patch
+
+        from custom_components.roomba_plus.image import PrimeRoomsImage
+
+        entity = object.__new__(PrimeRoomsImage)
+        entity._live_dirty = False
+        entity._last_live_state_write = 0.0
+        entity.async_write_ha_state = MagicMock()
+
+        with patch("custom_components.roomba_plus.image._time_mod.monotonic", side_effect=(10.0, 11.0, 12.0)):
+            entity._on_live_position()
+            entity._on_live_position()
+            entity._on_live_position()
+
+        assert entity._live_dirty
+        assert entity.async_write_ha_state.call_count == 2
 
     def test_live_layers_are_rendered_without_changing_the_room_fit(self):
         """The live bundle is a layer, not a second coordinate system."""

--- a/tests/test_prime_room_map.py
+++ b/tests/test_prime_room_map.py
@@ -899,7 +899,7 @@ class TestLiveTrail:
 
         source = inspect.getsource(PrimeMapImage._feed_trail)
 
-        assert "_METRES_TO_MM" in source
+        assert "METRES_TO_MM" in source
 
     def test_radians_are_converted_to_degrees(self):
         """Quieter version of the same mistake: the trail would be drawn
@@ -1001,7 +1001,7 @@ class TestBareGeoJsonFeature:
     robots you have."""
 
     def test_a_bare_feature_is_read(self):
-        from custom_components.roomba_plus.prime_room_map import _rings_mm
+        from custom_components.roomba_plus.prime_room_map import rings_mm
 
         bare = {
             "type": "Feature",
@@ -1011,10 +1011,10 @@ class TestBareGeoJsonFeature:
             },
         }
 
-        assert len(_rings_mm(bare)) == 1
+        assert len(rings_mm(bare)) == 1
 
     def test_a_feature_collection_still_works(self):
-        from custom_components.roomba_plus.prime_room_map import _rings_mm
+        from custom_components.roomba_plus.prime_room_map import rings_mm
 
         collection = {
             "type": "FeatureCollection",
@@ -1026,12 +1026,12 @@ class TestBareGeoJsonFeature:
             }],
         }
 
-        assert len(_rings_mm(collection)) == 1
+        assert len(rings_mm(collection)) == 1
 
     def test_a_bare_multipolygon_feature_is_read(self):
         """Borders are MultiPolygon, so the two quirks combine on exactly
         the layer where they were found."""
-        from custom_components.roomba_plus.prime_room_map import _rings_mm
+        from custom_components.roomba_plus.prime_room_map import rings_mm
 
         bare = {
             "type": "Feature",
@@ -1041,7 +1041,7 @@ class TestBareGeoJsonFeature:
             },
         }
 
-        rings = _rings_mm(bare)
+        rings = rings_mm(bare)
 
         assert len(rings) == 1
         assert rings[0][1] == (2000.0, 0.0)
@@ -1120,7 +1120,7 @@ class TestLiveBundleUpdatesTheRoomsMap:
 
         assert "async_add_executor_job" in source
 
-    def test_live_coverage_is_rendered_without_changing_the_room_fit(self):
+    def test_live_layers_are_rendered_without_changing_the_room_fit(self):
         """The live bundle is a layer, not a second coordinate system."""
         import io
 
@@ -1149,16 +1149,33 @@ class TestLiveBundleUpdatesTheRoomsMap:
                         ],
                     }
                 }]
-            }
+            },
+            "trajectories": {
+                "features": [{
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[0.25, 0.25], [0.75, 0.25]],
+                    }
+                }]
+            },
+            "hazard": {
+                "features": [{
+                    "geometry": {"type": "Point", "coordinates": [1.75, 1.75]}
+                }]
+            },
         }
         entity._config_entry = SimpleNamespace(
             runtime_data=SimpleNamespace(prime_positions=[]), options={}
         )
 
         image = Image.open(io.BytesIO(entity._render_png())).convert("RGB")
-        px, py = entity._renderer._mm_to_px_fit(1000.0, 1000.0)  # noqa: SLF001
+        coverage_px = entity._renderer._mm_to_px_fit(1000.0, 1000.0)  # noqa: SLF001
+        trajectory_px = entity._renderer._mm_to_px_fit(500.0, 250.0)  # noqa: SLF001
+        hazard_px = entity._renderer._mm_to_px_fit(1750.0, 1750.0)  # noqa: SLF001
 
-        assert image.getpixel((round(px), round(py))) == (120, 190, 145)
+        assert image.getpixel(tuple(map(round, coverage_px))) == (120, 190, 145)
+        assert image.getpixel(tuple(map(round, trajectory_px))) == (80, 150, 235)
+        assert image.getpixel(tuple(map(round, hazard_px))) == (240, 150, 60)
 
 
 class TestPolygonVerticesAreNotPoses:


### PR DESCRIPTION
## Summary

Restores the live rendering supplied by #63 that was dropped during the alpha 16 refactor, while retaining the alpha 17 static-map fit and border fixes.

- render live cleaned coverage, trajectories, hazards, and the current robot marker from `livemap_url`
- use distinct bundle and position dispatcher signals
- mark the Rooms Map dirty on live updates, render it only when Home Assistant fetches the image, and limit frontend refresh notifications to once every two seconds
- retain the last working geometry when a post-mission refresh temporarily returns no room geometry
- reuse public `METRES_TO_MM` and `rings_mm` helpers for every live layer
- preserve the current static room geometry, fit transform, and outline-only borders

## Validation

- `pytest tests/test_prime_room_map.py -q` — 70 passed
- `pytest tests/ -q` — only two existing `tests/test_presence_manager.py::TestRecordCleanEvent` timezone failures remain; the Prime map tests pass
- `python3 -m py_compile custom_components/roomba_plus/image.py tests/test_prime_room_map.py`
- `git diff --check`

## Screenshot

<img width="1070" height="824" alt="image" src="https://github.com/user-attachments/assets/3ffacd43-f683-4978-bb68-aca70cba52ec" />