### PR TITLE
fix(map): make Prime Rooms Map interactive and live

### DIFF
--- a/custom_components/roomba_plus/__init__.py
+++ b/custom_components/roomba_plus/__init__.py
@@ -1472,6 +1472,11 @@ async def _async_setup_entry_prime(hass: HomeAssistant, config_entry: RoombaConf
         config_entry.add_update_listener(_async_reload_on_options_change)
     )
 
+    # Domain actions are shared by Classic and Prime.  The Classic setup
+    # path registers them during its final phase, but Prime returns before
+    # that phase; register them here once runtime_data is available.
+    async_register_services(hass)
+
     # FAVOURITES, read once now that runtime_data exists.
     #
     # Before the platforms load, because the button platform reads the

--- a/custom_components/roomba_plus/binary_sensor.py
+++ b/custom_components/roomba_plus/binary_sensor.py
@@ -110,7 +110,9 @@ async def async_setup_entry(
             # Absent field means no entity. A present field means one,
             # whatever its value -- False is a real answer ("the tank is
             # out"), only absence means "this robot has no such thing".
-            if _prime_reports_tank(config_entry):
+            # A reported tankPresent field alone is not enough: vacuum-only
+            # Max 705s report it although cap.scrub explicitly says no mop.
+            if (cap is None or cap.scrub != 0) and _prime_reports_tank(config_entry):
                 entities.append(PrimeTankPresentSensor(data.blid, config_entry))
             async_add_entities(entities)
         return

--- a/custom_components/roomba_plus/binary_sensor.py
+++ b/custom_components/roomba_plus/binary_sensor.py
@@ -110,10 +110,12 @@ async def async_setup_entry(
             # Absent field means no entity. A present field means one,
             # whatever its value -- False is a real answer ("the tank is
             # out"), only absence means "this robot has no such thing".
-            # A reported tankPresent field alone is not enough: vacuum-only
-            # Max 705s report it although cap.scrub explicitly says no mop.
-            if (cap is None or cap.scrub != 0) and _prime_reports_tank(config_entry):
-                entities.append(PrimeTankPresentSensor(data.blid, config_entry))
+            if _prime_reports_tank(config_entry):
+                entities.append(PrimeTankPresentSensor(
+                    data.blid,
+                    config_entry,
+                    disabled=cap is not None and cap.scrub == 0,
+                ))
             async_add_entities(entities)
         return
 
@@ -1425,9 +1427,12 @@ class PrimeTankPresentSensor(_PrimeStatusSensorBase, BinarySensorEntity):
     # the others inconsistent for no reason.
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, blid: str, config_entry: RoombaConfigEntry) -> None:
+    def __init__(
+        self, blid: str, config_entry: RoombaConfigEntry, *, disabled: bool = False
+    ) -> None:
         super().__init__(blid, config_entry)
         self._attr_unique_id = f"{self.robot_unique_id}_mop_tank_present"
+        self._attr_entity_registry_enabled_default = not disabled
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/roomba_plus/button_prime.py
+++ b/custom_components/roomba_plus/button_prime.py
@@ -412,11 +412,12 @@ async def async_build_prime_buttons(
     # empty-now action. One look, no run.
     if _dock_reports_itself(config_entry):
         for command in PRIME_DOCK_COMMANDS:
-            # None means unknown, only an explicit 0 means absent -- so a
-            # robot that has not reported its dock yet still gets the
-            # buttons rather than silently losing them.
-            if (dock_cap is not None
-                    and getattr(dock_cap, command.dock_cap_attr, None) == 0):
+            # No dock-capability object is unknown; a field missing from an
+            # object the dock has reported is an unsupported feature.
+            if (
+                dock_cap is not None
+                and getattr(dock_cap, command.dock_cap_attr, None) in (None, 0)
+            ):
                 continue
             entities.append(PrimeDockButton(data.blid, config_entry, command))
 

--- a/custom_components/roomba_plus/button_prime.py
+++ b/custom_components/roomba_plus/button_prime.py
@@ -218,7 +218,12 @@ class PrimeDockButton(IRobotEntity, ButtonEntity):
     _attr_has_entity_name = True
 
     def __init__(
-        self, blid: str, config_entry: RoombaConfigEntry, command: PrimeDockCommand
+        self,
+        blid: str,
+        config_entry: RoombaConfigEntry,
+        command: PrimeDockCommand,
+        *,
+        disabled: bool = False,
     ) -> None:
         IRobotEntity.__init__(
             self, roomba=None, blid=blid, config_entry=config_entry
@@ -227,6 +232,7 @@ class PrimeDockButton(IRobotEntity, ButtonEntity):
         self._command = command
         self._attr_translation_key = command.key
         self._attr_unique_id = f"{self.robot_unique_id}_{command.key}"
+        self._attr_entity_registry_enabled_default = not disabled
 
     @property
     def suggested_object_id(self) -> str:
@@ -412,14 +418,13 @@ async def async_build_prime_buttons(
     # empty-now action. One look, no run.
     if _dock_reports_itself(config_entry):
         for command in PRIME_DOCK_COMMANDS:
-            # No dock-capability object is unknown; a field missing from an
-            # object the dock has reported is an unsupported feature.
-            if (
-                dock_cap is not None
-                and getattr(dock_cap, command.dock_cap_attr, None) in (None, 0)
-            ):
-                continue
-            entities.append(PrimeDockButton(data.blid, config_entry, command))
+            entities.append(PrimeDockButton(
+                data.blid,
+                config_entry,
+                command,
+                disabled=dock_cap is not None
+                and getattr(dock_cap, command.dock_cap_attr, None) in (None, 0),
+            ))
 
     # Locate is always offered; favourite buttons are optional.
     #

--- a/custom_components/roomba_plus/icons.json
+++ b/custom_components/roomba_plus/icons.json
@@ -345,6 +345,9 @@
       }
     },
     "image": {
+      "cleaning_map": {
+        "default": "mdi:robot-vacuum"
+      },
       "coverage_map": {
         "default": "mdi:map-legend"
       },

--- a/custom_components/roomba_plus/image.py
+++ b/custom_components/roomba_plus/image.py
@@ -3214,9 +3214,11 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
             p2map_id = current if current in map_ids else map_ids[0]
         self._current_map_id = p2map_id
 
-        saved_bundle = self._stored_live_bundle
+        # Some lightweight callers (including HA's entity test helpers)
+        # construct the image without running async_added_to_hass().
+        saved_bundle = getattr(self, "_stored_live_bundle", None)
         if (
-            self._live_bundle is None
+            getattr(self, "_live_bundle", None) is None
             and isinstance(saved_bundle, dict)
             and saved_bundle.get("map_id") == p2map_id
             and isinstance(saved_bundle.get("bundle"), dict)
@@ -3830,8 +3832,10 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         will never display.
         """
         self._live_bundle = bundle
-        if self._live_bundle_store is not None and self._current_map_id is not None:
-            self._live_bundle_store.async_delay_save(
+        live_bundle_store = getattr(self, "_live_bundle_store", None)
+        current_map_id = getattr(self, "_current_map_id", None)
+        if live_bundle_store is not None and current_map_id is not None:
+            live_bundle_store.async_delay_save(
                 self._live_bundle_save_payload,
                 _LIVE_BUNDLE_SAVE_DELAY_SECONDS,
             )
@@ -3841,7 +3845,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         """Persist only the rendered live layers for the current map."""
         bundle = self._live_bundle if isinstance(self._live_bundle, dict) else {}
         return {
-            "map_id": self._current_map_id,
+            "map_id": getattr(self, "_current_map_id", None),
             "bundle": {
                 layer: bundle[layer]
                 for layer in _LIVE_BUNDLE_LAYERS

--- a/custom_components/roomba_plus/image.py
+++ b/custom_components/roomba_plus/image.py
@@ -3865,7 +3865,10 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         rooms: dict[str, dict[str, Any]] = {}
         for room_id, ring in self._polygons.items():
             name = self._names.get(room_id) or f"Room {room_id}"
-            rooms[name] = {
+            # xiaomi-vacuum-map-card uses the mapping key as the selection
+            # id when it generates room config. Keep the app's stable ID
+            # there; the display name remains the room's label.
+            rooms[room_id] = {
                 "outline": [[x, y] for x, y in ring],
                 "name": name,
                 "room_id": room_id,

--- a/custom_components/roomba_plus/image.py
+++ b/custom_components/roomba_plus/image.py
@@ -207,6 +207,12 @@ async def async_setup_entry(
                 PrimeRoomsImage(
                     blid=data.blid, config_entry=config_entry, hass=hass
                 ),
+                PrimeRoomsImage(
+                    blid=data.blid,
+                    config_entry=config_entry,
+                    hass=hass,
+                    include_live=True,
+                ),
             ])
         return
 
@@ -377,8 +383,11 @@ class PrimeMapImage(IRobotEntity, ImageEntity):
     same pattern already used for the REST-fetched map bundle.
     """
 
-    _attr_translation_key = "map"
-    _attr_entity_category = None
+    _attr_translation_key = "raw_map"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    # This entity owns the V4 live-map subscription and dispatches its
+    # packets to the rendered map entities, so it cannot be disabled.
+    _attr_entity_registry_enabled_default = True
     _attr_content_type = "image/png"
 
     def __init__(self, prime_robot: Any, blid: str, config_entry: RoombaConfigEntry) -> None:
@@ -3060,7 +3069,7 @@ class RoombaRoomsImage(IRobotEntity, ImageEntity):
             )
 
 class PrimeRoomsImage(IRobotEntity, ImageEntity):
-    """V4/Prime room map: polygons drawn, names exposed as attributes.
+    """V4/Prime static floor plan or live cleaning map.
 
     BUILT THE SAME WAY AS RoombaRoomsImage, on purpose. The canvas
     colour, the rotating ROOM_FILL_PALETTE fill, the fixed outline
@@ -3089,7 +3098,12 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
     _attr_entity_category  = None
 
     def __init__(
-        self, blid: str, config_entry: RoombaConfigEntry, hass: Any
+        self,
+        blid: str,
+        config_entry: RoombaConfigEntry,
+        hass: Any,
+        *,
+        include_live: bool = False,
     ) -> None:
         IRobotEntity.__init__(
             self, roomba=None, blid=blid, config_entry=config_entry
@@ -3100,7 +3114,16 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # entity is never created.
         ImageEntity.__init__(self, hass)
         self._config_entry = config_entry
-        self._attr_unique_id = f"{self.robot_unique_id}_rooms_map"
+        self._include_live = include_live
+        # The rooms image is the xiaomi-vacuum-map-card source.  It must
+        # receive the live layers too: the card accepts one raster source,
+        # not a stack of image entities.
+        self._show_live_overlay = True
+        if include_live:
+            self._attr_translation_key = "cleaning_map"
+            self._attr_unique_id = f"{self.robot_unique_id}_prime_cleaning_map"
+        else:
+            self._attr_unique_id = f"{self.robot_unique_id}_rooms_map"
         self._attr_image_last_updated = dt_util.now(datetime.timezone.utc)
         self._polygons: dict[str, list[tuple[float, float]]] = {}
         self._names: dict[str, str] = {}
@@ -3122,7 +3145,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         """Locale-independent slug. With has_entity_name plus a
         translation_key, HA would otherwise derive the entity_id from the
         TRANSLATED name and produce different ids per language."""
-        return "rooms_map"
+        return "prime_cleaning_map" if self._include_live else "rooms_map"
 
     @property
     def available(self) -> bool:
@@ -3131,38 +3154,42 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         Honest rather than a blank canvas: a robot that has not finished
         mapping has no rooms, and an empty image looks like a fault.
         """
-        return super().available and bool(self._polygons)
+        return super().available and bool(
+            self._polygons or getattr(self._floor_plan, "floor_plan", None)
+        )
 
     async def async_added_to_hass(self) -> None:
         await IRobotEntity.async_added_to_hass(self)
-        self._live_bundle_store = Store(
-            self.hass,
-            _LIVE_BUNDLE_STORAGE_VERSION,
-            f"roomba_plus_prime_live_bundle_{self._config_entry.entry_id}",
-        )
-        stored = await self._live_bundle_store.async_load()
-        if isinstance(stored, dict):
-            self._stored_live_bundle = stored
+        if self._show_live_overlay:
+            self._live_bundle_store = Store(
+                self.hass,
+                _LIVE_BUNDLE_STORAGE_VERSION,
+                f"roomba_plus_prime_live_bundle_{self._config_entry.entry_id}",
+            )
+            stored = await self._live_bundle_store.async_load()
+            if isinstance(stored, dict):
+                self._stored_live_bundle = stored
         await self._async_refresh_rooms()
 
         # LIVE BUNDLES from the other Prime image entity, which watches
         # the map stream. The two are split by capability: that one has
         # the stream and no renderer, this one has the renderer and no
         # stream.
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                _SIGNAL_PRIME_LIVE_BUNDLE.format(self._config_entry.entry_id),
-                self._on_live_bundle,
+        if self._show_live_overlay:
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self.hass,
+                    _SIGNAL_PRIME_LIVE_BUNDLE.format(self._config_entry.entry_id),
+                    self._on_live_bundle,
+                )
             )
-        )
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                _SIGNAL_PRIME_LIVE_POSITION.format(self._config_entry.entry_id),
-                self._on_live_position,
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self.hass,
+                    _SIGNAL_PRIME_LIVE_POSITION.format(self._config_entry.entry_id),
+                    self._on_live_position,
+                )
             )
-        )
 
         # NO SUBSCRIPTION, and no re-render per image request.
         #
@@ -3218,6 +3245,8 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # construct the image without running async_added_to_hass().
         saved_bundle = getattr(self, "_stored_live_bundle", None)
         if (
+            getattr(self, "_show_live_overlay", True)
+            and
             getattr(self, "_live_bundle", None) is None
             and isinstance(saved_bundle, dict)
             and saved_bundle.get("map_id") == p2map_id
@@ -3257,7 +3286,8 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
             await async_build_prime_floor_plan(self._config_entry, p2map_id, version)
             if version
             else PrimeFloorPlan(
-                room_names={}, room_polygons={}, borders=[], carpet=[], dock=None
+                room_names={}, room_polygons={}, floor_plan=[], borders=[],
+                carpet=[], furniture=[], dock=None,
             )
         )
 
@@ -3295,12 +3325,12 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
                 room_id,
                 (floor_plan.room_names or {}).get(room_id) or f"Room {room_id}",
             )
-        if not polygons:
+        if not polygons and not floor_plan.floor_plan:
             # A post-mission shadow can announce a new map version before
             # its bundle is available. Do not turn a working map unavailable
             # just because this transient refresh has no geometry.
             _LOGGER.debug(
-                "Prime rooms map: refresh returned no geometry; keeping cached map"
+                "Prime map: refresh returned no geometry; keeping cached map"
             )
             return
 
@@ -3383,8 +3413,10 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # which is why its map is complete before the first mission.
         rings = [
             *self._polygons.values(),
+            *getattr(self._floor_plan, "floor_plan", ()),
             *self._floor_plan.carpet,
             *self._floor_plan.borders,
+            *getattr(self._floor_plan, "furniture", ()),
         ]
         self._renderer._points = [  # noqa: SLF001
             self._renderer._mm_to_px(x, y)  # noqa: SLF001
@@ -3401,22 +3433,30 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         draw = ImageDraw.Draw(img)
 
         to_px = self._renderer._mm_to_px_fit  # noqa: SLF001
-        live_bundle = self._live_bundle or {}
+        show_live = getattr(self, "_show_live_overlay", True)
+        show_room_fills = getattr(self, "_include_live", True)
+        live_bundle = self._live_bundle or {} if show_live else {}
         live_coverage = rings_mm(live_bundle.get("coverage"))
 
-        # LAYER ORDER MATTERS, bottom to top: rooms, then carpet, then
-        # walls, then the dock, then labels.
+        # LAYER ORDER MATTERS, bottom to top: rooms, coverage, structural
+        # floor plan, then furniture and borders.
         #
         # Carpet over rooms because it is a property OF a room, and a
         # room drawn on top would hide it. Walls over both because they
         # bound everything. The dock over walls because it sits against
         # one. Labels last so nothing covers them.
-        for idx, ring in enumerate(self._polygons.values()):
-            draw.polygon(
-                [to_px(x, y) for x, y in ring],
-                outline=(100, 149, 237),
-                fill=ROOM_FILL_PALETTE[idx % len(ROOM_FILL_PALETTE)],
+        if show_room_fills:
+            room_outline = (
+                None
+                if getattr(self._floor_plan, "floor_plan", ())
+                else (100, 149, 237)
             )
+            for idx, ring in enumerate(self._polygons.values()):
+                draw.polygon(
+                    [to_px(x, y) for x, y in ring],
+                    outline=room_outline,
+                    fill=ROOM_FILL_PALETTE[idx % len(ROOM_FILL_PALETTE)],
+                )
 
         for ring in self._floor_plan.carpet:
             # Outline only, no fill: a filled overlay would flatten the
@@ -3428,6 +3468,29 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # share its coordinate frame and must not move the room layout.
         for ring in live_coverage:
             draw.polygon([to_px(x, y) for x, y in ring], fill=(120, 190, 145))
+
+        # Older bundles have room regions but no detailed floor plan.
+        # Keep that static image useful without pretending it has walls.
+        if not show_room_fills and not getattr(self._floor_plan, "floor_plan", ()):
+            for ring in self._polygons.values():
+                draw.polygon(
+                    [to_px(x, y) for x, y in ring], outline=(175, 175, 175), width=2
+                )
+
+        # `rooms` marks where the robot can clean.  `floorPlan` is the
+        # detailed saved-map geometry the iRobot app uses for interior
+        # walls and doorways.  It shares the map coordinate system, so it
+        # must use the same fit transform rather than a second registration.
+        for ring in getattr(self._floor_plan, "floor_plan", ()):
+            points = [to_px(x, y) for x, y in ring]
+            draw.line(points, fill=(175, 175, 175), width=2)
+
+        # Furniture is useful context, but an outline keeps it from hiding
+        # the selectable room colours or live cleaning coverage.
+        for ring in getattr(self._floor_plan, "furniture", ()):
+            draw.polygon(
+                [to_px(x, y) for x, y in ring], outline=(90, 90, 90), width=1
+            )
 
         for ring in self._floor_plan.borders:
             # OUTLINE ONLY, for the reason written two lines above about
@@ -3460,7 +3523,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # a restart mid-run -- the bundle fills in.
         have_own_trail = bool(
             getattr(self._config_entry.runtime_data, "prime_positions", None)
-        )
+        ) if show_live else False
         for feature in (
             [] if have_own_trail
             else (live_bundle.get("trajectories") or {}).get("features") or []
@@ -3488,7 +3551,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # different questions -- where the robot should go, where it must
         # not, and where it must not mop -- and wanting keep-out zones on
         # screen does not imply wanting clean zones too.
-        options = self._config_entry.options
+        options = self._config_entry.options if show_live else {}
         # ZONES COME FROM WHICHEVER BUNDLE HAS THEM.
         #
         # The live bundle arrives on a map-update message -- only while a
@@ -3567,9 +3630,11 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # that path maintains its own bounds and coordinate frame, and
         # this map is already anchored on the room polygons. Two frames
         # for one picture would misplace one of them.
-        positions = getattr(
-            self._config_entry.runtime_data, "prime_positions", None
-        ) or []
+        positions = (
+            getattr(self._config_entry.runtime_data, "prime_positions", None) or []
+            if show_live
+            else []
+        )
         if len(positions) >= 2:
             trail: list[tuple[float, float]] = []
             previous: tuple[float, float] | None = None
@@ -3603,7 +3668,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # because nothing invoked it. Found by listing private helpers
         # whose name appears exactly once in the component.
         dock_xy = self._dock_position()
-        if dock_xy is not None:
+        if show_live and dock_xy is not None:
             # THE SAME WHITE RING AS THE ROBOT, for the same reason.
             #
             # The dock reads clearly against the trail (a difference of
@@ -3680,7 +3745,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # The option exists for everyone not using that card -- a plain
         # picture-entity shows an image and nothing else, so for them the
         # names have to be in the picture or they do not exist.
-        if self._config_entry.options.get(
+        if show_room_fills and self._config_entry.options.get(
             CONF_MAP_ROOM_LABELS, DEFAULT_MAP_ROOM_LABELS
         ):
             from .map_renderer import LABEL_FONT  # noqa: PLC0415
@@ -3708,7 +3773,7 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         map change is picked up without a subscription.
         """
         await self._async_refresh_if_map_changed()
-        if self._live_dirty and self._polygons:
+        if getattr(self, "_show_live_overlay", True) and self._live_dirty and self._polygons:
             self._png = await self.hass.async_add_executor_job(self._render_png)
             self._live_dirty = False
         return self._png
@@ -3785,12 +3850,12 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Calibration and room outlines for xiaomi-vacuum-map-card.
 
-        Same keys and same coordinate convention as the Classic rooms
-        map, so a card configuration written for one works for the other.
+        The static Rooms Map is the card source.  The Cleaning Map is a
+        rendered status image, so it must not advertise selectable rooms.
         """
         from .prime_room_map import prime_calibration_points
 
-        if not self._polygons or self._renderer is None:
+        if self._include_live or not self._polygons or self._renderer is None:
             return {}
 
         cal = prime_calibration_points(

--- a/custom_components/roomba_plus/image.py
+++ b/custom_components/roomba_plus/image.py
@@ -102,6 +102,9 @@ _MAX_PRIME_POSITIONS = 5000
 _SIGNAL_PRIME_LIVE_BUNDLE = "roomba_plus_prime_live_bundle_{}"
 _SIGNAL_PRIME_LIVE_POSITION = "roomba_plus_prime_live_position_{}"
 _LIVE_MAP_STATE_UPDATE_INTERVAL = 2.0
+_LIVE_BUNDLE_STORAGE_VERSION = 1
+_LIVE_BUNDLE_SAVE_DELAY_SECONDS = 5
+_LIVE_BUNDLE_LAYERS = ("coverage", "trajectories", "hazard")
 PARALLEL_UPDATES = 0
 
 # ROOM-PALETTE (v2.9.0) — rotating per-room fill colours for _render_rooms_png().
@@ -3108,6 +3111,11 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         self._png: bytes | None = None
         self._live_dirty = False
         self._last_live_state_write = 0.0
+        self._live_bundle_store: Store | None = None
+        self._stored_live_bundle: dict[str, Any] | None = None
+        self._current_map_id: str | None = None
+        self._rendered_for_map_version: str | None = None
+        self._rendered_map_id: str | None = None
 
     @property
     def suggested_object_id(self) -> str:
@@ -3127,6 +3135,14 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
 
     async def async_added_to_hass(self) -> None:
         await IRobotEntity.async_added_to_hass(self)
+        self._live_bundle_store = Store(
+            self.hass,
+            _LIVE_BUNDLE_STORAGE_VERSION,
+            f"roomba_plus_prime_live_bundle_{self._config_entry.entry_id}",
+        )
+        stored = await self._live_bundle_store.async_load()
+        if isinstance(stored, dict):
+            self._stored_live_bundle = stored
         await self._async_refresh_rooms()
 
         # LIVE BUNDLES from the other Prime image entity, which watches
@@ -3168,11 +3184,9 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         # the thing worth watching -- and it is already being read for
         # room cleaning. Checked when the image is requested, and the
         # cloud is only called when it has actually moved.
-        self._rendered_for_map_version: str | None = None
         #: Which map that version belongs to. Without it, a robot moving
         #: between floors would render a different map while the version
         #: it is compared against stays put.
-        self._rendered_map_id: str | None = None
 
     async def _async_refresh_rooms(self) -> None:
         """Reads the current map's rooms and renders them."""
@@ -3198,6 +3212,16 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         else:
             current = await backend._current_map_id()  # noqa: SLF001
             p2map_id = current if current in map_ids else map_ids[0]
+        self._current_map_id = p2map_id
+
+        saved_bundle = self._stored_live_bundle
+        if (
+            self._live_bundle is None
+            and isinstance(saved_bundle, dict)
+            and saved_bundle.get("map_id") == p2map_id
+            and isinstance(saved_bundle.get("bundle"), dict)
+        ):
+            self._live_bundle = saved_bundle["bundle"]
 
         polygons, names, preferences = await async_build_prime_room_polygons(
             self._config_entry, p2map_id
@@ -3806,7 +3830,24 @@ class PrimeRoomsImage(IRobotEntity, ImageEntity):
         will never display.
         """
         self._live_bundle = bundle
+        if self._live_bundle_store is not None and self._current_map_id is not None:
+            self._live_bundle_store.async_delay_save(
+                self._live_bundle_save_payload,
+                _LIVE_BUNDLE_SAVE_DELAY_SECONDS,
+            )
         self._mark_live_dirty()
+
+    def _live_bundle_save_payload(self) -> dict[str, Any]:
+        """Persist only the rendered live layers for the current map."""
+        bundle = self._live_bundle if isinstance(self._live_bundle, dict) else {}
+        return {
+            "map_id": self._current_map_id,
+            "bundle": {
+                layer: bundle[layer]
+                for layer in _LIVE_BUNDLE_LAYERS
+                if isinstance(bundle.get(layer), (dict, list))
+            },
+        }
 
     @callback
     def _on_live_position(self) -> None:

--- a/custom_components/roomba_plus/prime_room_map.py
+++ b/custom_components/roomba_plus/prime_room_map.py
@@ -235,12 +235,17 @@ class PrimeFloorPlan:
     #: the ONLY place outlines exist -- get_map_metadata() returns names
     #: and cleaning defaults but no geometry.
     room_polygons: dict[str, list[tuple[float, float]]]
+    #: Fine-grained floor-plan outlines, including interior walls and
+    #: doorway cut-outs.  These are separate from cleanable room polygons.
+    floor_plan: list[list[tuple[float, float]]]
     borders: list[list[tuple[float, float]]]
     #: Carpeted areas. The only observed floor_type value is "carpet",
     #: which suggests the file lists carpet rather than classifying every
     #: surface -- anything uncovered is hard floor by omission. Not
     #: confirmed: a robot with no carpet would settle it.
     carpet: list[list[tuple[float, float]]]
+    #: Detected furniture outlines from the saved map.
+    furniture: list[list[tuple[float, float]]]
     #: Dock position and which way it faces, or None.
     dock: tuple[float, float, float] | None
     #: The raw `cleanZones`, `adHocCleanZones` and `policyZones` files,
@@ -318,12 +323,14 @@ def _room_polygons_from_bundle(
     return polygons
 
 
-def rings_mm(features: Any) -> list[list[tuple[float, float]]]:
-    """Every outer ring in a GeoJSON FeatureCollection, in millimetres.
+def rings_mm(
+    features: Any, *, include_holes: bool = False
+) -> list[list[tuple[float, float]]]:
+    """GeoJSON polygon rings in millimetres.
 
-    Handles Polygon and MultiPolygon in one pass, because borders use the
-    latter and floor types the former, and the difference is not worth
-    two functions.
+    Floor-plan holes are structural outlines too, so callers can retain
+    them with ``include_holes``.  Other layers intentionally use only an
+    outer ring.
     """
     rings: list[list[tuple[float, float]]] = []
 
@@ -345,18 +352,52 @@ def rings_mm(features: Any) -> list[list[tuple[float, float]]]:
         # MultiPolygon nests one level deeper than Polygon.
         polygons = coords if kind == "MultiPolygon" else [coords]
         for polygon in polygons:
-            if not polygon:
-                continue
+            for coordinates in (polygon if include_holes else polygon[:1]):
+                try:
+                    ring = [
+                        (float(x) * METRES_TO_MM, float(y) * METRES_TO_MM)
+                        for x, y in coordinates
+                    ]
+                except (TypeError, ValueError, IndexError):
+                    continue
+                if len(ring) >= 3:
+                    rings.append(ring)
+    return rings
+
+
+def lines_mm(features: Any) -> list[list[tuple[float, float]]]:
+    """GeoJSON line paths in millimetres, retaining wall openings."""
+    lines: list[list[tuple[float, float]]] = []
+    if isinstance(features, dict) and features.get("type") == "Feature":
+        features = {"features": [features]}
+
+    for feature in (features or {}).get("features") or []:
+        geometry = feature.get("geometry") or {}
+        coords = geometry.get("coordinates") or []
+        kind = geometry.get("type")
+        if kind == "MultiLineString":
+            paths = coords
+        elif kind == "LineString":
+            paths = [coords]
+        elif kind == "Polygon":
+            paths = coords
+        elif kind == "MultiPolygon":
+            paths = [ring for polygon in coords for ring in polygon]
+        else:
+            paths = []
+        for path in paths:
             try:
-                ring = [
+                line = [
                     (float(x) * METRES_TO_MM, float(y) * METRES_TO_MM)
-                    for x, y in polygon[0]
+                    for x, y in path
                 ]
             except (TypeError, ValueError, IndexError):
                 continue
-            if len(ring) >= 3:
-                rings.append(ring)
-    return rings
+            if len(line) >= 2:
+                if kind in {"Polygon", "MultiPolygon"} and line[0] != line[-1]:
+                    line.append(line[0])
+                lines.append(line)
+    return lines
 
 
 def _carpet_rings_mm(features: Any) -> list[list[tuple[float, float]]]:
@@ -412,7 +453,8 @@ async def async_build_prime_floor_plan(
     data = config_entry.runtime_data
     robot = getattr(data, "prime_robot", None)
     empty = PrimeFloorPlan(
-        room_names={}, room_polygons={}, borders=[], carpet=[], dock=None
+        room_names={}, room_polygons={}, floor_plan=[], borders=[], carpet=[],
+        furniture=[], dock=None,
     )
     if robot is None:
         return empty
@@ -482,8 +524,10 @@ async def async_build_prime_floor_plan(
         },
         room_names=_room_names_from_bundle(parsed.get("rooms")),
         room_polygons=_room_polygons_from_bundle(parsed.get("rooms")),
+        floor_plan=lines_mm(parsed.get("floorPlan")),
         borders=rings_mm(parsed.get("borders")),
         carpet=_carpet_rings_mm(parsed.get("floorTypes")),
+        furniture=rings_mm(parsed.get("furniture")),
         dock=_dock_from(parsed.get("dockPose")),
     )
     _LOGGER.debug(

--- a/custom_components/roomba_plus/room_cleaning.py
+++ b/custom_components/roomba_plus/room_cleaning.py
@@ -417,7 +417,9 @@ class PrimeRoomCleaning(RoomCleaningBackend):
         current_map = await self._current_map_id()
         rooms: dict[str, str] = {}
         from_current: set[str] = set()
-        bundle_names = getattr(self._data, "prime_room_names", {}) or {}
+        bundle_names = getattr(self._data, "prime_room_names", None)
+        if not isinstance(bundle_names, dict):
+            bundle_names = {}
         map_ids = await self._all_map_ids()
 
         def add_room(name: str, p2map_id: str, room_id: str) -> None:
@@ -478,8 +480,9 @@ class PrimeRoomCleaning(RoomCleaningBackend):
                 floor_plan = await async_build_prime_floor_plan(
                     self._config_entry, p2map_id, version
                 )
-                for room_id, room_name in floor_plan.room_names.items():
-                    add_room(room_name, p2map_id, room_id)
+                if isinstance(floor_plan.room_names, dict):
+                    for room_id, room_name in floor_plan.room_names.items():
+                        add_room(room_name, p2map_id, room_id)
         except Exception:  # noqa: BLE001
             _LOGGER.debug("roomba_plus: could not read bundle room names", exc_info=True)
         return rooms

--- a/custom_components/roomba_plus/room_cleaning.py
+++ b/custom_components/roomba_plus/room_cleaning.py
@@ -417,8 +417,29 @@ class PrimeRoomCleaning(RoomCleaningBackend):
         current_map = await self._current_map_id()
         rooms: dict[str, str] = {}
         from_current: set[str] = set()
+        bundle_names = getattr(self._data, "prime_room_names", {}) or {}
+        map_ids = await self._all_map_ids()
 
-        for p2map_id in await self._all_map_ids():
+        def add_room(name: str, p2map_id: str, room_id: str) -> None:
+            """Keep the current map's room when names collide."""
+            is_current = bool(current_map) and p2map_id == current_map
+            if name in rooms:
+                if is_current and name not in from_current:
+                    _LOGGER.warning(
+                        "roomba_plus: room name %r exists on more than one map "
+                        "for %s -- using the one on the map the robot is "
+                        "currently on. Rename one of them in the iRobot app to "
+                        "target them separately.",
+                        name, self._data.blid,
+                    )
+                    rooms[name] = f"{p2map_id}/{room_id}"
+                    from_current.add(name)
+                return
+            rooms[name] = f"{p2map_id}/{room_id}"
+            if is_current:
+                from_current.add(name)
+
+        for p2map_id in map_ids:
             try:
                 map_data = await self._robot.get_map_metadata(p2map_id)
             except Exception:  # noqa: BLE001
@@ -428,35 +449,39 @@ class PrimeRoomCleaning(RoomCleaningBackend):
                 )
                 continue
 
-            is_current = bool(current_map) and p2map_id == current_map
-
             for room in map_data.rooms_metadata or []:
-                if not (room.name and room.room_id):
+                room_id = getattr(room, "room_id", None)
+                room_name = getattr(room, "name", None) or bundle_names.get(
+                    str(room_id)
+                )
+                if not (room_name and room_id):
                     continue
 
-                if room.name in rooms:
-                    if is_current and room.name not in from_current:
-                        _LOGGER.warning(
-                            "roomba_plus: room name %r exists on more than one map "
-                            "for %s -- using the one on the map the robot is "
-                            "currently on. Rename one of them in the iRobot app to "
-                            "target them separately.",
-                            room.name, self._data.blid,
-                        )
-                        rooms[room.name] = f"{p2map_id}/{room.room_id}"
-                        from_current.add(room.name)
-                    else:
-                        _LOGGER.warning(
-                            "roomba_plus: room name %r exists on more than one map "
-                            "for %s -- keeping the first match. Rename one of them "
-                            "in the iRobot app to target them separately.",
-                            room.name, self._data.blid,
-                        )
-                    continue
+                add_room(room_name, p2map_id, str(room_id))
 
-                rooms[room.name] = f"{p2map_id}/{room.room_id}"
-                if is_current:
-                    from_current.add(room.name)
+        # The metadata endpoint is incomplete on some Prime accounts. The
+        # rooms bundle is the app's source of truth for names and includes
+        # regions metadata omits (such as this robot's hallway).
+        try:
+            from .prime_room_map import async_build_prime_floor_plan
+
+            versions = await self._robot.get_active_map_versions() or []
+            version_by_map = {
+                str(entry["p2map_id"]): entry.get("active_p2mapv_id")
+                for entry in versions
+                if entry.get("p2map_id") and entry.get("active_p2mapv_id")
+            }
+            for p2map_id in map_ids:
+                version = version_by_map.get(p2map_id)
+                if not version:
+                    continue
+                floor_plan = await async_build_prime_floor_plan(
+                    self._config_entry, p2map_id, version
+                )
+                for room_id, room_name in floor_plan.room_names.items():
+                    add_room(room_name, p2map_id, room_id)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("roomba_plus: could not read bundle room names", exc_info=True)
         return rooms
 
     _SEGMENT_PREFIX = "rid_"

--- a/custom_components/roomba_plus/room_cleaning.py
+++ b/custom_components/roomba_plus/room_cleaning.py
@@ -86,12 +86,28 @@ def match_room_names(
     """
     by_name = {name.casefold(): rid for name, rid in available.items()}
     by_slug = {room_slug(name): rid for name, rid in available.items()}
+    # Map cards select stable region ids, whereas the service is normally
+    # called with room names.  Accept a bare id only when it is unique across
+    # the known maps; a duplicate needs its map-qualified value instead.
+    raw_ids: dict[str, list[str]] = {}
+    for room_id in available.values():
+        value = str(room_id)
+        raw_ids.setdefault(value.rsplit("/", 1)[-1], []).append(value)
+    by_id = {
+        room_id: values[0]
+        for room_id, values in raw_ids.items()
+        if len(values) == 1
+    }
 
     matched: list[str] = []
     unmatched: list[str] = []
     for raw in requested:
         wanted = raw.strip()
-        rid = by_name.get(wanted.casefold()) or by_slug.get(room_slug(wanted))
+        rid = (
+            by_name.get(wanted.casefold())
+            or by_slug.get(room_slug(wanted))
+            or by_id.get(wanted)
+        )
         if rid is None:
             unmatched.append(raw)
         elif rid not in matched:

--- a/custom_components/roomba_plus/sensor.py
+++ b/custom_components/roomba_plus/sensor.py
@@ -527,6 +527,11 @@ def _add_prime_mission_sensors(
         wanted |= _PRIME_MISSION_SENSOR_KEYS
     if getattr(data, "maintenance_store", None) is not None:
         wanted |= _PRIME_MAINTENANCE_SENSOR_KEYS
+        from .prime_coordinator import get_prime_capability_flags
+
+        cap, _dock_cap = get_prime_capability_flags(config_entry)
+        if cap is not None and cap.scrub == 0:
+            wanted.discard("pad_last_replaced")
     entities: list[Any] = [
         RoombaSensor(None, data.blid, description, config_entry)
         for description in SENSORS

--- a/custom_components/roomba_plus/sensor.py
+++ b/custom_components/roomba_plus/sensor.py
@@ -280,10 +280,17 @@ async def async_setup_entry(
         # was present and the key absent, here the object never comes.
         dock_known = _dock_reports_itself(config_entry)
         dock_cap_known = dock_cap is not None
-        if dock_known and (not dock_cap_known or dock_cap.pad_wash not in (0, None)):
-            entities.append(PrimePadWashStatusSensor(data.blid, config_entry))
-        if dock_known and (not dock_cap_known or dock_cap.pad_dry not in (0, None)):
-            entities.append(PrimePadDryStatusSensor(data.blid, config_entry))
+        if dock_known:
+            entities.append(PrimePadWashStatusSensor(
+                data.blid,
+                config_entry,
+                disabled=dock_cap_known and dock_cap.pad_wash in (0, None),
+            ))
+            entities.append(PrimePadDryStatusSensor(
+                data.blid,
+                config_entry,
+                disabled=dock_cap_known and dock_cap.pad_dry in (0, None),
+            ))
         # PRESENCE, not capability. See PrimeDockTankLevelSensor's
         # docstring: which docks report tankLvl is not decidable from
         # dock.cap, and a sensor reading "unknown" forever is worse than
@@ -523,6 +530,7 @@ def _add_prime_mission_sensors(
     room list.
     """
     wanted: set[str] = set()
+    disable_pad_maintenance = False
     if getattr(data, "mission_store", None) is not None:
         wanted |= _PRIME_MISSION_SENSOR_KEYS
     if getattr(data, "maintenance_store", None) is not None:
@@ -530,13 +538,15 @@ def _add_prime_mission_sensors(
         from .prime_coordinator import get_prime_capability_flags
 
         cap, _dock_cap = get_prime_capability_flags(config_entry)
-        if cap is not None and cap.scrub == 0:
-            wanted.discard("pad_last_replaced")
-    entities: list[Any] = [
-        RoombaSensor(None, data.blid, description, config_entry)
-        for description in SENSORS
-        if description.key in wanted
-    ]
+        disable_pad_maintenance = cap is not None and cap.scrub == 0
+    entities: list[Any] = []
+    for description in SENSORS:
+        if description.key not in wanted:
+            continue
+        entity = RoombaSensor(None, data.blid, description, config_entry)
+        if description.key == "pad_last_replaced" and disable_pad_maintenance:
+            entity._attr_entity_registry_enabled_default = False
+        entities.append(entity)
 
     # Mission progress: elapsed time, current room, remaining estimate.
     # Not part of SENSORS -- it is its own entity class, and Classic

--- a/custom_components/roomba_plus/sensor_prime.py
+++ b/custom_components/roomba_plus/sensor_prime.py
@@ -624,9 +624,12 @@ class PrimePadWashStatusSensor(_PrimeCurrentStateSensorBase):
     )
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, blid: str, config_entry: RoombaConfigEntry) -> None:
+    def __init__(
+        self, blid: str, config_entry: RoombaConfigEntry, *, disabled: bool = False
+    ) -> None:
         super().__init__(blid, config_entry)
         self._attr_unique_id = f"{self.robot_unique_id}_prime_pad_wash_status"
+        self._attr_entity_registry_enabled_default = not disabled
 
     @property
     def native_value(self) -> str | None:
@@ -689,9 +692,12 @@ class PrimePadDryStatusSensor(_PrimeCurrentStateSensorBase):
     )
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, blid: str, config_entry: RoombaConfigEntry) -> None:
+    def __init__(
+        self, blid: str, config_entry: RoombaConfigEntry, *, disabled: bool = False
+    ) -> None:
         super().__init__(blid, config_entry)
         self._attr_unique_id = f"{self.robot_unique_id}_prime_pad_dry_status"
+        self._attr_entity_registry_enabled_default = not disabled
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/roomba_plus/strings.json
+++ b/custom_components/roomba_plus/strings.json
@@ -1132,6 +1132,12 @@
       "map": {
         "name": "Cleaning map"
       },
+      "raw_map": {
+        "name": "Raw live map"
+      },
+      "cleaning_map": {
+        "name": "Cleaning map"
+      },
       "coverage_map": {
         "name": "Coverage map"
       },

--- a/custom_components/roomba_plus/switch.py
+++ b/custom_components/roomba_plus/switch.py
@@ -186,6 +186,7 @@ async def async_setup_entry(
     # own CLOUD_ONLY branch -- Prime data comes from PrimeStatusCoordinator's
     # named-shadow data, not roomba_reported_state()'s Classic shape.
     if data.connection_type is ConnectionType.CLOUD_ONLY:
+        cap = dock_cap = None
         if data.prime_status_coordinator is not None:
             from .prime_coordinator import get_prime_capability_flags
 
@@ -787,4 +788,3 @@ class PrimeSettingSwitch(IRobotEntity, SwitchEntity):
             self.async_on_remove(
                 coordinator.async_add_listener(self.async_write_ha_state)
             )
-

--- a/custom_components/roomba_plus/switch.py
+++ b/custom_components/roomba_plus/switch.py
@@ -204,9 +204,16 @@ async def async_setup_entry(
         # boost switch uses -- a robot that has not reported its
         # capabilities yet should get the switch, not lose it.
         setting_entities = [
-            PrimeSettingSwitch(data.blid, config_entry, description)
+            PrimeSettingSwitch(
+                data.blid,
+                config_entry,
+                description,
+                disabled=description.dock_cap_attr is not None
+                and dock_cap is not None
+                and getattr(dock_cap, description.dock_cap_attr, None) in (None, 0),
+            )
             for description in PRIME_SETTING_SWITCHES
-            if _capability_permits(description, cap, dock_cap)
+            if _capability_permits(description, cap, None)
         ]
         if setting_entities:
             async_add_entities(setting_entities)
@@ -724,6 +731,8 @@ class PrimeSettingSwitch(IRobotEntity, SwitchEntity):
         blid: str,
         config_entry: RoombaConfigEntry,
         description: PrimeSettingSwitchDescription,
+        *,
+        disabled: bool = False,
     ) -> None:
         IRobotEntity.__init__(
             self, roomba=None, blid=blid, config_entry=config_entry
@@ -731,6 +740,7 @@ class PrimeSettingSwitch(IRobotEntity, SwitchEntity):
         self.entity_description = description
         self._config_entry = config_entry
         self._attr_unique_id = f"{self.robot_unique_id}_{description.key}"
+        self._attr_entity_registry_enabled_default = not disabled
 
     @property
     def suggested_object_id(self) -> str:

--- a/custom_components/roomba_plus/translations/de.json
+++ b/custom_components/roomba_plus/translations/de.json
@@ -1125,6 +1125,12 @@
       "map": {
         "name": "Reinigungskarte"
       },
+      "raw_map": {
+        "name": "Rohe Live-Karte"
+      },
+      "cleaning_map": {
+        "name": "Reinigungskarte"
+      },
       "coverage_map": {
         "name": "Bedeckungskarte"
       },

--- a/custom_components/roomba_plus/translations/en.json
+++ b/custom_components/roomba_plus/translations/en.json
@@ -1125,6 +1125,12 @@
       "map": {
         "name": "Cleaning map"
       },
+      "raw_map": {
+        "name": "Raw live map"
+      },
+      "cleaning_map": {
+        "name": "Cleaning map"
+      },
       "coverage_map": {
         "name": "Coverage map"
       },

--- a/custom_components/roomba_plus/translations/es.json
+++ b/custom_components/roomba_plus/translations/es.json
@@ -1125,6 +1125,12 @@
       "map": {
         "name": "Mapa de limpieza"
       },
+      "raw_map": {
+        "name": "Mapa en directo sin procesar"
+      },
+      "cleaning_map": {
+        "name": "Mapa de limpieza"
+      },
       "coverage_map": {
         "name": "Mapa de cobertura"
       },

--- a/custom_components/roomba_plus/translations/fr.json
+++ b/custom_components/roomba_plus/translations/fr.json
@@ -1125,6 +1125,12 @@
       "map": {
         "name": "Carte de nettoyage"
       },
+      "raw_map": {
+        "name": "Carte en direct brute"
+      },
+      "cleaning_map": {
+        "name": "Carte de nettoyage"
+      },
       "coverage_map": {
         "name": "Carte de couverture"
       },

--- a/custom_components/roomba_plus/translations/it.json
+++ b/custom_components/roomba_plus/translations/it.json
@@ -1125,6 +1125,12 @@
       "map": {
         "name": "Mappa di pulizia"
       },
+      "raw_map": {
+        "name": "Mappa dal vivo grezza"
+      },
+      "cleaning_map": {
+        "name": "Mappa di pulizia"
+      },
       "coverage_map": {
         "name": "Mappa di copertura"
       },

--- a/custom_components/roomba_plus/translations/nl.json
+++ b/custom_components/roomba_plus/translations/nl.json
@@ -1123,6 +1123,12 @@
     },
     "image": {
       "map": {
+        "name": "Schoonmaakkaart"
+      },
+      "raw_map": {
+        "name": "Ruwe livekaart"
+      },
+      "cleaning_map": {
         "name": "Reinigingskaart"
       },
       "coverage_map": {

--- a/custom_components/roomba_plus/translations/pl.json
+++ b/custom_components/roomba_plus/translations/pl.json
@@ -1125,6 +1125,12 @@
       "map": {
         "name": "Mapa sprzątania"
       },
+      "raw_map": {
+        "name": "Surowa mapa na żywo"
+      },
+      "cleaning_map": {
+        "name": "Mapa sprzątania"
+      },
       "coverage_map": {
         "name": "Mapa pokrycia"
       },

--- a/custom_components/roomba_plus/translations/pt.json
+++ b/custom_components/roomba_plus/translations/pt.json
@@ -1125,6 +1125,12 @@
       "map": {
         "name": "Mapa de limpeza"
       },
+      "raw_map": {
+        "name": "Mapa em direto em bruto"
+      },
+      "cleaning_map": {
+        "name": "Mapa de limpeza"
+      },
       "coverage_map": {
         "name": "Mapa de cobertura"
       },

--- a/custom_components/roomba_plus/vacuum.py
+++ b/custom_components/roomba_plus/vacuum.py
@@ -531,14 +531,19 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
         (self.vacuum is None) -- and unlike async_added_to_hass() (called
         once at setup), this property is evaluated on every state write,
         so this would have crashed immediately and repeatedly, not just
-        once. "status"/error attrs are None for CLOUD_ONLY -- honest "no
-        data available" (no master_state-shaped translation exists yet,
-        see RobotStatusV2 blocker), not a fabricated guess.
+        once.  Error attrs remain absent for CLOUD_ONLY.  ``status`` is
+        derived from the same confirmed ``activity`` mapping that supplies
+        the vacuum entity state, so cards that explicitly read this legacy
+        attribute (including xiaomi-vacuum-map-card) see the live state.
         """
         state = self.vacuum_state
         attrs: dict[str, Any] = {
             ATTR_SOFTWARE_VERSION: state.get("softwareVer"),
-            "status": self.vacuum.current_state if self.vacuum is not None else None,
+            "status": (
+                self.vacuum.current_state
+                if self.vacuum is not None
+                else self.activity.value
+            ),
         }
 
         # Cleaning progress (only while actively cleaning)

--- a/tests/test_button_prime.py
+++ b/tests/test_button_prime.py
@@ -60,6 +60,15 @@ def _entry(favorites=None, raises=False, dock=False):
     return entry
 
 
+def _enabled(entities):
+    """Entities a default Home Assistant install exposes."""
+    return [
+        entity
+        for entity in entities
+        if getattr(entity, "_attr_entity_registry_enabled_default", True)
+    ]
+
+
 class TestFavouriteButtons:
     """A favourite is a stored routine -- "clean the kitchen and hall on
     deep, twice" -- and pressing it runs that.
@@ -77,7 +86,7 @@ class TestFavouriteButtons:
             _entry([_favorite("f1"), _favorite("f2")])
         )
 
-        assert len(entities) == 3  # two favourites + locate
+        assert len(_enabled(entities)) == 3  # two favourites + locate
 
     @pytest.mark.asyncio
     async def test_pressing_sends_every_command_in_order(self):
@@ -113,7 +122,7 @@ class TestFavouriteButtons:
             _favorite("f2", hidden=True),
         ]))
 
-        assert len(entities) == 1  # locate only
+        assert len(_enabled(entities)) == 1  # locate only
 
     @pytest.mark.asyncio
     async def test_a_favourite_with_no_commands_warns_rather_than_silently_failing(self):
@@ -157,7 +166,7 @@ class TestFavouriteButtons:
 
         entities = await async_build_prime_buttons(_entry([]))
 
-        assert len(entities) == 1
+        assert len(_enabled(entities)) == 1
 
     @pytest.mark.asyncio
     async def test_buttons_do_not_re_read_the_favourites(self):
@@ -295,8 +304,8 @@ class TestFavoriteButtonsAreOptional:
 
         entities = await async_build_prime_buttons(entry)
 
-        assert len(entities) == 1
-        assert not any(hasattr(e, "_favorite_id") for e in entities)
+        assert len(_enabled(entities)) == 1
+        assert not any(hasattr(e, "_favorite_id") for e in _enabled(entities))
 
     def test_the_default_is_on(self):
         from custom_components.roomba_plus.const import (
@@ -371,7 +380,7 @@ class TestDockButtons:
         assert sum(isinstance(e, PrimeDockButton) for e in entities) == 4
 
     @pytest.mark.asyncio
-    async def test_a_dock_that_cannot_do_something_gets_no_button(self):
+    async def test_unsupported_dock_buttons_are_disabled(self):
         """A robot without a self-emptying base still reports its own
         capabilities happily -- the DOCK flags are what say whether a
         base is there."""
@@ -382,7 +391,9 @@ class TestDockButtons:
 
         entities = await async_build_prime_buttons(_entry(dock=False))
 
-        assert not any(isinstance(e, PrimeDockButton) for e in entities)
+        dock_buttons = [e for e in entities if isinstance(e, PrimeDockButton)]
+        assert len(dock_buttons) == 4
+        assert not _enabled(dock_buttons)
 
     @pytest.mark.asyncio
     async def test_unknown_capabilities_still_get_buttons(self):

--- a/tests/test_button_prime.py
+++ b/tests/test_button_prime.py
@@ -289,7 +289,7 @@ class TestFavoriteButtonsAreOptional:
             async_build_prime_buttons,
         )
 
-        assert len(await async_build_prime_buttons(_entry([_favorite("f1")]))) == 2
+        assert len(_enabled(await async_build_prime_buttons(_entry([_favorite("f1")]))) == 2
 
     @pytest.mark.asyncio
     async def test_the_option_suppresses_only_the_favourites(self):

--- a/tests/test_button_prime.py
+++ b/tests/test_button_prime.py
@@ -289,7 +289,8 @@ class TestFavoriteButtonsAreOptional:
             async_build_prime_buttons,
         )
 
-        assert len(_enabled(await async_build_prime_buttons(_entry([_favorite("f1")]))) == 2
+        buttons = await async_build_prime_buttons(_entry([_favorite("f1")]))
+        assert len(_enabled(buttons)) == 2
 
     @pytest.mark.asyncio
     async def test_the_option_suppresses_only_the_favourites(self):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -194,6 +194,16 @@ class TestCoverageImageAttributes:
         datetime.datetime.fromisoformat(attrs["last_mission_end"])
 
 
+def test_prime_cleaning_map_does_not_advertise_card_rooms():
+    """Only the static Rooms Map is a xiaomi-vacuum-map-card source."""
+    from custom_components.roomba_plus.image import PrimeRoomsImage
+
+    entity = PrimeRoomsImage.__new__(PrimeRoomsImage)
+    entity._include_live = True
+
+    assert entity.extra_state_attributes == {}
+
+
 class TestCoverageImageIdentity:
     def test_unique_id_suffix(self):
         entity = _make_entity()

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -204,6 +204,24 @@ def test_prime_cleaning_map_does_not_advertise_card_rooms():
     assert entity.extra_state_attributes == {}
 
 
+def test_prime_rooms_map_uses_stable_ids_for_generated_room_config():
+    """The card generator uses the rooms mapping key as its selection ID."""
+    from custom_components.roomba_plus.image import PrimeRoomsImage
+
+    entity = PrimeRoomsImage.__new__(PrimeRoomsImage)
+    entity._include_live = False
+    entity._polygons = {"10": [(0.0, 0.0), (1000.0, 0.0), (1000.0, 1000.0)]}
+    entity._names = {"10": "Kitchen"}
+    entity._preferences = {}
+    entity._renderer = MagicMock()
+    entity._renderer._mm_to_px_fit.side_effect = lambda x, y: (x, y)
+
+    rooms = entity.extra_state_attributes["rooms"]
+    assert list(rooms) == ["10"]
+    assert rooms["10"]["name"] == "Kitchen"
+    assert rooms["10"]["room_id"] == "10"
+
+
 class TestCoverageImageIdentity:
     def test_unique_id_suffix(self):
         entity = _make_entity()

--- a/tests/test_prime_room_map.py
+++ b/tests/test_prime_room_map.py
@@ -1101,8 +1101,8 @@ class TestStaticPrimeRoomsMap:
 
         assert entity.suggested_object_id == "prime_cleaning_map"
 
-    def test_static_map_omits_live_room_and_coverage_fills(self):
-        """The saved floor plan must not look like a completed mission."""
+    def test_card_source_includes_live_coverage(self):
+        """The static Rooms Map is also the card's live map source."""
         import io
 
         from PIL import Image
@@ -1111,6 +1111,7 @@ class TestStaticPrimeRoomsMap:
 
         entity = object.__new__(PrimeRoomsImage)
         entity._include_live = False
+        entity._show_live_overlay = True
         entity._renderer = None
         entity._polygons = {
             "room": [(0.0, 0.0), (2000.0, 0.0), (2000.0, 2000.0), (0.0, 2000.0)]
@@ -1129,7 +1130,7 @@ class TestStaticPrimeRoomsMap:
 
         image = Image.open(io.BytesIO(entity._render_png())).convert("RGB")
 
-        assert image.getpixel((300, 300)) == (30, 30, 30)
+        assert image.getpixel((300, 300)) == (120, 190, 145)
 
 
 class TestLiveBundleUpdatesTheRoomsMap:

--- a/tests/test_prime_room_map.py
+++ b/tests/test_prime_room_map.py
@@ -586,6 +586,42 @@ class TestFloorPlanFromTheMapBundle:
         assert len(plan.carpet) == 1
 
     @pytest.mark.asyncio
+    async def test_floor_plan_holes_and_furniture_are_loaded(self):
+        """The saved-map detail layer retains interior wall outlines."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from custom_components.roomba_plus.prime_room_map import (
+            async_build_prime_floor_plan,
+        )
+
+        outer = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]]
+        inner = [[1.0, 1.0], [3.0, 1.0], [3.0, 3.0], [1.0, 3.0]]
+        furniture = [[1.5, 1.5], [2.5, 1.5], [2.5, 2.5], [1.5, 2.5]]
+        parsed = {
+        "floorPlan": {"features": [{"geometry": {
+            "type": "MultiLineString", "coordinates": [outer, inner],
+        }}]},
+            "furniture": {"features": [{"geometry": {
+                "type": "Polygon", "coordinates": [furniture],
+            }}]},
+        }
+        entry = MagicMock()
+        entry.runtime_data.prime_robot.get_map_geojson_link = AsyncMock(
+            return_value={"map_url": "https://x"}
+        )
+        entry.runtime_data.prime_robot.download_map_bundle = AsyncMock(return_value=b"x")
+
+        with patch(
+            "roombapy_prime.models.map_bundle.parse_map_bundle", return_value=parsed
+        ):
+            plan = await async_build_prime_floor_plan(entry, "MAP-1", "V1")
+
+        assert len(plan.floor_plan) == 2
+        assert plan.floor_plan[0][0] == (0.0, 0.0)
+        assert plan.floor_plan[0][1] == (4000.0, 0.0)
+        assert len(plan.furniture) == 1
+
+    @pytest.mark.asyncio
     async def test_the_dock_carries_an_orientation(self):
         """Confirmed from the capture's key list. Means a rendered dock
         can point the right way rather than being a dot."""
@@ -1055,6 +1091,47 @@ class TestBareGeoJsonFeature:
         assert rings[0][1] == (2000.0, 0.0)
 
 
+class TestStaticPrimeRoomsMap:
+    def test_live_variant_has_a_non_colliding_entity_slug(self):
+        """The existing raw image already owns ``cleaning_map`` on upgrades."""
+        from custom_components.roomba_plus.image import PrimeRoomsImage
+
+        entity = object.__new__(PrimeRoomsImage)
+        entity._include_live = True
+
+        assert entity.suggested_object_id == "prime_cleaning_map"
+
+    def test_static_map_omits_live_room_and_coverage_fills(self):
+        """The saved floor plan must not look like a completed mission."""
+        import io
+
+        from PIL import Image
+
+        from custom_components.roomba_plus.image import PrimeRoomsImage
+
+        entity = object.__new__(PrimeRoomsImage)
+        entity._include_live = False
+        entity._renderer = None
+        entity._polygons = {
+            "room": [(0.0, 0.0), (2000.0, 0.0), (2000.0, 2000.0), (0.0, 2000.0)]
+        }
+        entity._floor_plan = SimpleNamespace(
+            floor_plan=[], furniture=[], carpet=[], borders=[], dock=None
+        )
+        entity._live_bundle = {
+            "coverage": {"features": [{"geometry": {"type": "Polygon", "coordinates": [
+                [[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5]]
+            ]}}]}
+        }
+        entity._config_entry = SimpleNamespace(
+            runtime_data=SimpleNamespace(prime_positions=[]), options={}
+        )
+
+        image = Image.open(io.BytesIO(entity._render_png())).convert("RGB")
+
+        assert image.getpixel((300, 300)) == (30, 30, 30)
+
+
 class TestLiveBundleUpdatesTheRoomsMap:
     """The rooms map redraws during a mission, not only when the map
     version changes.
@@ -1157,6 +1234,10 @@ class TestLiveBundleUpdatesTheRoomsMap:
         from custom_components.roomba_plus.image import PrimeRoomsImage
 
         entity = object.__new__(PrimeRoomsImage)
+        # The xiaomi card uses the static Rooms Map.  It must retain its
+        # selectable-room attributes while still rendering live layers.
+        entity._include_live = False
+        entity._show_live_overlay = True
         entity._renderer = None
         entity._polygons = {
             "room": [

--- a/tests/test_prime_room_map.py
+++ b/tests/test_prime_room_map.py
@@ -2180,3 +2180,23 @@ class TestZonesDoNotNeedARunningMission:
 
         source = inspect.getsource(PrimeRoomsImage)
         assert 'getattr(self._floor_plan, "zone_layers", None)' in source
+    def test_live_bundle_storage_excludes_unrendered_layers(self):
+        from custom_components.roomba_plus.image import PrimeRoomsImage
+
+        entity = object.__new__(PrimeRoomsImage)
+        entity._current_map_id = "MAP-1"
+        entity._live_bundle = {
+            "coverage": {"features": []},
+            "trajectories": {"features": []},
+            "hazard": {"features": []},
+            "rooms": {"features": []},
+        }
+
+        assert entity._live_bundle_save_payload() == {
+            "map_id": "MAP-1",
+            "bundle": {
+                "coverage": {"features": []},
+                "trajectories": {"features": []},
+                "hazard": {"features": []},
+            },
+        }

--- a/tests/test_prime_setup.py
+++ b/tests/test_prime_setup.py
@@ -119,7 +119,9 @@ class TestAsyncSetupEntryPrime:
         with patch(
             "custom_components.roomba_plus.PrimeFactory.create_prime_robot",
             new=AsyncMock(return_value=fake_prime_robot),
-        ) as mock_create:
+        ) as mock_create, patch(
+            "custom_components.roomba_plus.async_register_services"
+        ) as register_services:
             result = await _async_setup_entry_prime(hass, config_entry)
 
         assert result is True
@@ -141,6 +143,7 @@ class TestAsyncSetupEntryPrime:
         assert runtime_data.prime_household_id == "hh1"
         assert runtime_data.prime_serial_info is fake_serial_info
         fake_prime_robot.connect.assert_awaited_once()
+        register_services.assert_called_once_with(hass)
 
     @pytest.mark.asyncio
     async def test_serial_info_failure_does_not_block_setup(self) -> None:

--- a/tests/test_room_cleaning.py
+++ b/tests/test_room_cleaning.py
@@ -422,6 +422,10 @@ class TestRoomNameMatching:
     def test_an_exact_name_matches(self):
         assert self._match(["Salon"]) == (["13"], [])
 
+    def test_a_unique_room_id_matches(self):
+        """Map cards select the API id while displaying the room name."""
+        assert self._match(["13"]) == (["13"], [])
+
     def test_case_does_not_matter(self):
         """Automations and voice assistants are inconsistent about it."""
         assert self._match(["salon"]) == (["13"], [])

--- a/tests/test_room_cleaning.py
+++ b/tests/test_room_cleaning.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -344,6 +344,23 @@ class TestPrimeRoomCleaning:
         backend, _robot = self._backend(maps=[{"p2map_id": "MAP-9"}])
 
         assert await backend.available_rooms()
+
+    @pytest.mark.asyncio
+    async def test_bundle_name_fills_a_room_missing_from_metadata(self):
+        """Prime metadata can omit a named region that exists in the map bundle."""
+        backend, _robot = self._backend(
+            maps=[{"p2map_id": "MAP-1", "active_p2mapv_id": "VERSION-1"}]
+        )
+        backend._config_entry = MagicMock()
+        floor_plan = MagicMock(room_names={"11": "Hallway"})
+
+        with patch(
+            "custom_components.roomba_plus.prime_room_map.async_build_prime_floor_plan",
+            new=AsyncMock(return_value=floor_plan),
+        ):
+            rooms = await backend.available_rooms()
+
+        assert rooms["Hallway"] == "MAP-1/11"
 
     @pytest.mark.asyncio
     async def test_no_map_yields_no_rooms_rather_than_an_error(self):

--- a/tests/test_sensor_prime.py
+++ b/tests/test_sensor_prime.py
@@ -354,7 +354,7 @@ class TestAsyncSetupEntryCapabilityGating:
         assert "prime_detected_pad" in keys
         assert "prime_suction_level" in keys or "suction_level" in keys
     @pytest.mark.asyncio
-    async def test_dock_cap_zero_excludes_pad_wash_and_dry(self):
+    async def test_dock_cap_zero_disables_pad_wash_and_dry(self):
         from custom_components.roomba_plus import sensor as sensor_mod
         from custom_components.roomba_plus.sensor_prime import (
             PrimePadDryStatusSensor, PrimePadWashStatusSensor,
@@ -364,8 +364,12 @@ class TestAsyncSetupEntryCapabilityGating:
         created = []
         await sensor_mod.async_setup_entry(MagicMock(), entry, lambda e, **kw: created.extend(e))
 
-        assert not any(isinstance(e, PrimePadWashStatusSensor) for e in created)
-        assert not any(isinstance(e, PrimePadDryStatusSensor) for e in created)
+        pad_sensors = [
+            e for e in created
+            if isinstance(e, (PrimePadWashStatusSensor, PrimePadDryStatusSensor))
+        ]
+        assert len(pad_sensors) == 2
+        assert all(not e._attr_entity_registry_enabled_default for e in pad_sensors)
 
 
 class TestDockStateLabel:
@@ -754,16 +758,15 @@ class TestDockCapabilityGating:
     Applying the same rule to a nested object that IS present was the
     mistake."""
 
-    def test_an_evac_only_dock_gets_no_pad_sensors(self):
+    def test_an_evac_only_dock_disables_pad_sensors(self):
         import inspect
 
         from custom_components.roomba_plus import sensor
 
         source = inspect.getsource(sensor.async_setup_entry)
 
-        # None and 0 both suppress; only a real capability creates.
-        assert "pad_wash not in (0, None)" in source
-        assert "pad_dry not in (0, None)" in source
+        assert "disabled=dock_cap_known and dock_cap.pad_wash in (0, None)" in source
+        assert "disabled=dock_cap_known and dock_cap.pad_dry in (0, None)" in source
 
     def test_a_missing_dock_cap_still_fails_open(self):
         """A robot whose shadow has not arrived must not silently lose
@@ -824,7 +827,7 @@ class TestCapabilityGatesHandleNone:
                     f"{path.name}: gating on cap.{field}, which is always None"
                 )
 
-    def test_dock_gates_treat_none_as_absent(self):
+    def test_dock_gates_disable_none_and_zero(self):
         import inspect
 
         from custom_components.roomba_plus import sensor
@@ -832,7 +835,7 @@ class TestCapabilityGatesHandleNone:
         source = inspect.getsource(sensor.async_setup_entry)
 
         for field in ("pad_wash", "pad_dry"):
-            assert f"{field} not in (0, None)" in source, field
+            assert f"{field} in (0, None)" in source, field
 
     def test_robot_gates_treat_none_as_unknown(self):
         """Deliberately the other way round, and it must stay that way:

--- a/tests/test_sensor_prime.py
+++ b/tests/test_sensor_prime.py
@@ -779,7 +779,7 @@ class TestDockCapabilityGating:
         source = inspect.getsource(sensor.async_setup_entry)
 
         assert "dock_cap_known" in source
-        assert "not dock_cap_known or" in source
+        assert "disabled=dock_cap_known" in source
 
 
 

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -1218,7 +1218,7 @@ class TestCloudOnlyVacuumActions:
             with patch.object(v, "schedule_update_ha_state"):
                 await v.async_added_to_hass()  # must not raise
 
-    def test_extra_state_attributes_does_not_crash(self):
+    def test_extra_state_attributes_exposes_card_compatible_status(self):
         """Regression test for a second real bug in the same round: this
         property reads self.vacuum.current_state/error_code/error_message
         unconditionally -- worse than async_added_to_hass() since HA
@@ -1228,7 +1228,10 @@ class TestCloudOnlyVacuumActions:
 
         attrs = v.extra_state_attributes
 
-        assert attrs["status"] is None
+        # xiaomi-vacuum-map-card reads the legacy ``status`` attribute rather
+        # than HA's state.  Prime has no local ``current_state``, but activity
+        # is the confirmed source used for the entity state itself.
+        assert attrs["status"] == "idle"
         assert "error" not in attrs
         assert "error_code" not in attrs
 


### PR DESCRIPTION
## Summary

- use the saved floor-plan geometry for a wall-and-doorway Rooms Map while preserving xiaomi-vacuum-map-card calibration and selectable room overlays
- render live coverage, route, robot position, dock and hazards into that same Rooms Map image; the card has one raster map source and cannot stack the cleaning camera above it
- keep the separate Cleaning Map as a rendered status image without selectable-room attributes
- forward room selection via stable API room IDs while retaining friendly room labels, including bundle-only regions such as Hallway
- keep the raw live-map image as a diagnostic entity because it owns the Prime stream subscription that drives both rendered maps

## Why

The previous card could show either a room-selection map or a cleaning map, but not both: its map source is one image entity. The integration now composites the live layers onto the calibrated Rooms Map, so room selection remains first-class while the card tracks the active clean.

This preserves support for other models. Capability-specific controls remain registered and are only disabled where the robot explicitly reports them as unsupported.

## Validation

- Home Assistant test: selected rooms now invoke cleaning using the robot numeric IDs, while labels remain human-friendly
- Home Assistant test: the card retains room selection and receives the live-map source after the Raw Live Map stream entity is enabled
- `python3 -m py_compile` passed for the changed Python modules
- `git diff --check` passed

## Screenshots

Auto generating room config:

<img width="1101" height="961" alt="image" src="https://github.com/user-attachments/assets/64487750-60aa-409a-b0f0-430383c51c8d" />

Selecting areas to be cleaned:

<img width="640" height="806" alt="image" src="https://github.com/user-attachments/assets/ab12f273-7c4b-4b1a-831b-36ba75bd1a7f" />
