### PR TITLE
fix(prime): accept Rooms Map region IDs

### DIFF
--- a/custom_components/roomba_plus/room_cleaning.py
+++ b/custom_components/roomba_plus/room_cleaning.py
@@ -86,12 +86,24 @@ def match_room_names(
     """
     by_name = {name.casefold(): rid for name, rid in available.items()}
     by_slug = {room_slug(name): rid for name, rid in available.items()}
+    by_id: dict[str, str] = {}
+    ambiguous_ids: set[str] = set()
+    for rid in available.values():
+        bare_id = rid.rsplit("/", 1)[-1]
+        if bare_id in by_id and by_id[bare_id] != rid:
+            ambiguous_ids.add(bare_id)
+        else:
+            by_id[bare_id] = rid
 
     matched: list[str] = []
     unmatched: list[str] = []
     for raw in requested:
         wanted = raw.strip()
-        rid = by_name.get(wanted.casefold()) or by_slug.get(room_slug(wanted))
+        rid = (
+            by_name.get(wanted.casefold())
+            or by_slug.get(room_slug(wanted))
+            or (by_id.get(wanted) if wanted not in ambiguous_ids else None)
+        )
         if rid is None:
             unmatched.append(raw)
         elif rid not in matched:

--- a/custom_components/roomba_plus/vacuum.py
+++ b/custom_components/roomba_plus/vacuum.py
@@ -538,7 +538,9 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
         state = self.vacuum_state
         attrs: dict[str, Any] = {
             ATTR_SOFTWARE_VERSION: state.get("softwareVer"),
-            "status": self.vacuum.current_state if self.vacuum is not None else None,
+            "status": (
+                self.vacuum.current_state if self.vacuum is not None else self.activity.value
+            ),
         }
 
         # Cleaning progress (only while actively cleaning)

--- a/tests/test_room_cleaning.py
+++ b/tests/test_room_cleaning.py
@@ -405,6 +405,17 @@ class TestRoomNameMatching:
     def test_an_exact_name_matches(self):
         assert self._match(["Salon"]) == (["13"], [])
 
+    def test_a_unique_bare_prime_region_id_matches(self):
+        from custom_components.roomba_plus.room_cleaning import match_room_names
+
+        assert match_room_names({"Study": "MAP-1/16"}, ["16"]) == (["MAP-1/16"], [])
+
+    def test_an_ambiguous_bare_region_id_is_rejected(self):
+        from custom_components.roomba_plus.room_cleaning import match_room_names
+
+        rooms = {"Downstairs": "MAP-1/16", "Upstairs": "MAP-2/16"}
+        assert match_room_names(rooms, ["16"]) == ([], ["16"])
+
     def test_case_does_not_matter(self):
         """Automations and voice assistants are inconsistent about it."""
         assert self._match(["salon"]) == (["13"], [])

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -1228,7 +1228,7 @@ class TestCloudOnlyVacuumActions:
 
         attrs = v.extra_state_attributes
 
-        assert attrs["status"] is None
+        assert attrs["status"] == "idle"
         assert "error" not in attrs
         assert "error_code" not in attrs
 


### PR DESCRIPTION
## Summary

- accept unique bare Prime region IDs emitted by the Rooms Map image
- retain name/slug matching and reject ambiguous IDs across maps
- provide a Prime activity fallback for the vacuum `status` attribute

## Test plan

- `pytest -q tests/test_room_cleaning.py::TestRoomNameMatching tests/test_vacuum.py::TestCloudOnlyVacuumActions::test_extra_state_attributes_does_not_crash`
- verified on a Max 705: map-card room ID selection is accepted and the status attribute reports `docked`
