### PR TITLE
fix: live-instance investigation finding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Local test tooling artifacts (not part of the integration)
+.venv-test/
+__pycache__/
+*.pyc

--- a/custom_components/roomba_plus/__init__.py
+++ b/custom_components/roomba_plus/__init__.py
@@ -579,8 +579,14 @@ async def _phase_data(ctx: _SetupContext) -> None:
         "error", "stuck", "stuck_and_resumed", "stuck_and_abandoned"
     })
     for _rec in reversed(mission_store.records):
-        if _rec.get("result") in _ERROR_RESULTS and _rec.get("error_code"):
+        _res = _rec.get("result")
+        if _res in _ERROR_RESULTS and _rec.get("error_code"):
             last_error_code = _rec["error_code"]
+            last_error_at   = _rec.get("ended_at")
+            last_error_zone = (_rec.get("zones") or [None])[0]
+            break
+        elif _res in MissionStore.STUCK_RESULTS:
+            last_error_code = None
             last_error_at   = _rec.get("ended_at")
             last_error_zone = (_rec.get("zones") or [None])[0]
             break

--- a/custom_components/roomba_plus/button_prime.py
+++ b/custom_components/roomba_plus/button_prime.py
@@ -543,6 +543,19 @@ def _raw_favorite_is_for(favorite: dict[str, Any], blid: str) -> bool:
     return blid in attributed
 
 
+def _is_internal_favorite_name(name: str) -> bool:
+    """Whether a favourite name is a firmware-internal id rather than
+    something a user named in the app.
+
+    Confirmed case: `_mission_init_config_9A37307A20804F0CABE9B6011B82DDBE`.
+    Every such name starts with an underscore, and no favourite in this
+    project's fixtures or reports ever has -- iRobot's own app does not
+    let a user start a routine name that way -- so the check is the
+    general prefix rather than a match on that one string.
+    """
+    return name.startswith("_")
+
+
 def build_prime_favorite_buttons(
     config_entry: RoombaConfigEntry,
 ) -> list[PrimeFavoriteButton]:
@@ -583,11 +596,14 @@ def build_prime_favorite_buttons(
             # identified -- a button for it would be a dead one whose
             # unique_id collides with the next such entry.
             continue
+        name = favorite.get("name") or ""
+        if _is_internal_favorite_name(name):
+            continue
         buttons.append(PrimeFavoriteButton(
             data.blid,
             config_entry,
             str(favorite_id),
-            favorite.get("name") or "",
+            name,
         ))
     return buttons
 
@@ -693,6 +709,7 @@ async def async_favorites_attribute(
         if getattr(f, "favorite_id", None)
         and not getattr(f, "is_deleted", False)
         and not getattr(f, "is_hidden", False)
+        and not _is_internal_favorite_name(getattr(f, "name", "") or "")
         and _favorite_is_for(f, config_entry.runtime_data.blid)
     ]
 

--- a/custom_components/roomba_plus/callbacks.py
+++ b/custom_components/roomba_plus/callbacks.py
@@ -301,6 +301,37 @@ def _capture_zone_names(
     return []  # NONE (600-series) or SMART without cloud
 
 
+def _mission_already_terminal(entry: RoombaConfigEntry, mssn_strt_tm: int) -> bool:
+    """MissionStore already holds a terminal record for this mssnStrtTm
+    whose ended_at is within the MQTT re-delivery window -- i.e. a phase
+    flipping back to run/hmMidMsn/evac under the same mssnStrtTm is a
+    post-terminal replay pulse, not a new mission start.
+
+    A terminal record older than the window means a genuine new segment
+    (980/900-series multi-recharge keeps mssnStrtTm across segments), so
+    older terminal records do not suppress.
+    """
+    if not mssn_strt_tm:
+        return False
+    data: RoombaData = entry.runtime_data
+    store = data.mission_store
+    if store is None:
+        return False
+    from .mission_store import MissionStore
+    candidate_id = f"m_{mssn_strt_tm}"
+    now = dt_util.utcnow()
+    for r in store.records:
+        if (
+            MissionStore.base_mission_id(r.get("id")) == candidate_id
+            and MissionStore.is_terminal_result(r.get("result"))
+        ):
+            ended = r.get("ended_at")
+            ended_dt = dt_util.parse_datetime(ended) if ended else None
+            if ended_dt is None or (now - ended_dt).total_seconds() <= _CLOUD_CATCHUP_MISSION_MATCH_SEC:
+                return True
+    return False
+
+
 # ── Mission record builder ────────────────────────────────────────────────────
 
 async def async_record_mission(
@@ -459,7 +490,8 @@ async def async_record_mission(
         "npicks_delta": npicks_delta,   # v3.2.0 ANOMALY-EXPLAIN
     }
 
-    await data.mission_store.async_append(record)
+    if not data.mission_store.update_terminal_fields(record["id"], record):
+        await data.mission_store.async_append(record)
     await data.mission_store.async_save(hass, entry.entry_id)
 
     # v3.1.0 L9-MAP — update the personal relocalisation baseline.
@@ -495,6 +527,7 @@ async def async_record_mission(
         # would mix in mid-mission jitter unrelated to charge-cycle deltas.
         bbchg3 = _merged_top_level(entry, reported, "bbchg3")
         raw_estcap = bbchg3.get("estCap")
+        cycles_energy = active_charge_cycles(bbchg3)
         if raw_estcap:
             profile = data.robot_profile
             if profile is not None:
@@ -506,6 +539,16 @@ async def async_record_mission(
                 )
                 if estcap_mah is not None:
                     rps.record_estcap_observation(estcap_mah)
+                    # F12e — advance the lifetime energy high-water here,
+                    # where RobotProfileStore is already being persisted:
+                    # the sensor read path stays side-effect-free and a
+                    # restart between polls cannot lose the floor.
+                    voltage = profile.battery_voltage if profile else 14.8
+                    energy_kwh = round(
+                        estcap_mah * voltage * int(cycles_energy or 0) / 1_000_000, 3
+                    )
+                    if energy_kwh:
+                        rps.update_energy_high_water(energy_kwh)
                     await rps.async_save(hass, entry.entry_id)
 
     # v2.9.0 EVENT-BUS — fire roomba_plus_mission_completed for automations.
@@ -728,10 +771,20 @@ def make_mission_callback(
         # to 0 in the mission-end MQTT message.
         # v2.6.3 D — guard with had_cleaning_phase so stuck → run (recovery)
         # does NOT re-fire this block and corrupt mission_start_ts/nstuck_at_start.
-        if phase in _ACTIVE_CLEANING_PHASES and not had_cleaning_phase:
+        #
+        # A same mssnStrtTm reappearing here after MissionStore already
+        # holds a terminal record for it is a post-terminal replay pulse
+        # (stale/re-delivered MQTT state), not a genuine resume — treat it
+        # as inert enrichment instead of re-opening the mission.
+        _candidate_mission_start_ts = mission.get("mssnStrtTm") or 0
+        if (
+            phase in _ACTIVE_CLEANING_PHASES
+            and not had_cleaning_phase
+            and not _mission_already_terminal(entry, _candidate_mission_start_ts)
+        ):
             had_cleaning_phase = True
             current_mission_zones = _capture_zone_names(entry, reported)
-            mission_start_ts = mission.get("mssnStrtTm") or 0
+            mission_start_ts = _candidate_mission_start_ts
             bbrun = _merged_top_level(entry, reported, "bbrun")
             nstuck_at_start = bbrun.get("nStuck", 0)
             npicks_at_start = bbrun.get("nPicks", 0)

--- a/custom_components/roomba_plus/device_tracker.py
+++ b/custom_components/roomba_plus/device_tracker.py
@@ -64,12 +64,24 @@ PARALLEL_UPDATES = 0
 _DOCKED_LABEL: dict[str, str] = {
     "de": "Angedockt",
     "en": "Docked",
+    "es": "Acoplado",
+    "fr": "Sur la base",
+    "it": "Sulla base",
+    "nl": "Gedockt",
+    "pl": "Zadokowany",
+    "pt": "Na base",
 }
 #: Shown while the robot reports `stuck`. Its own state, not a place --
 #: which is the point: "Cleaning" was actively wrong there.
 _STUCK_LABEL: dict[str, str] = {
     "de": "Steckt fest",
     "en": "Stuck",
+    "es": "Atascado",
+    "fr": "Coincé",
+    "it": "Bloccato",
+    "nl": "Vastgelopen",
+    "pl": "Utknął",
+    "pt": "Preso",
 }
 
 #: Shown when the robot reports an error. Not a place -- which is the
@@ -77,11 +89,23 @@ _STUCK_LABEL: dict[str, str] = {
 _ERROR_LABEL: dict[str, str] = {
     "de": "Fehler",
     "en": "Error",
+    "es": "Error",
+    "fr": "Erreur",
+    "it": "Errore",
+    "nl": "Fout",
+    "pl": "Błąd",
+    "pt": "Erro",
 }
 
 _ACTIVE_FALLBACK_LABEL: dict[str, str] = {
     "de": "Unterwegs",
     "en": "Cleaning",
+    "es": "Limpiando",
+    "fr": "Nettoyage",
+    "it": "Pulizia",
+    "nl": "Schoonmaken",
+    "pl": "Sprzątanie",
+    "pt": "Limpando",
 }
 
 

--- a/custom_components/roomba_plus/grid_store.py
+++ b/custom_components/roomba_plus/grid_store.py
@@ -213,6 +213,7 @@ class GridStore:
         # _cells changes. Keyed dict (not scalar) so multiple edge_depth values
         # can coexist safely if future callers use non-default parameters.
         self._edge_ratio_cache: dict[float, float] = {}
+        self._last_valid_edge_coverage_ratio: float | None = None
         # v3.2.0 FURNITURE — rolling per-cell coverage-history bitmask
         # (bit 0 = most recent mission) + a companion age counter so a
         # freshly-tracked cell (fewer than _FURNITURE_WINDOW_BITS missions
@@ -344,6 +345,15 @@ class GridStore:
             # legitimate backfill candidate, which is the correct behaviour
             # for a robot upgrading onto this feature for the first time).
             self._last_processed_nmssn = int(data.get("last_processed_nmssn", 0) or 0)
+            last_valid_ratio = data.get("last_valid_edge_coverage_ratio")
+            self._last_valid_edge_coverage_ratio = (
+                float(last_valid_ratio)
+                if isinstance(last_valid_ratio, (int, float))
+                and not isinstance(last_valid_ratio, bool)
+                and math.isfinite(last_valid_ratio)
+                and 0.0 <= last_valid_ratio <= 1.0
+                else None
+            )
         except (KeyError, ValueError, IndexError, TypeError, AttributeError) as exc:
             _LOGGER.warning("GridStore: failed to load — %s; starting empty", exc)
             self._cells = {}
@@ -353,6 +363,7 @@ class GridStore:
             self._furniture_dismissed_at = {}
             self._structure_cells = {}
             self._last_processed_nmssn = 0
+            self._last_valid_edge_coverage_ratio = None
 
     async def async_save(self, hass: Any, entry_id: str) -> None:
         """Persist current grid to hass.storage."""
@@ -378,6 +389,7 @@ class GridStore:
                 f"{gx},{gy}": w for (gx, gy), w in self._structure_cells.items()
             },
             "last_processed_nmssn": self._last_processed_nmssn,
+            "last_valid_edge_coverage_ratio": self._last_valid_edge_coverage_ratio,
         })
 
     # ── Write ──────────────────────────────────────────────────────────────────
@@ -612,36 +624,29 @@ class GridStore:
         bounding box. A low ratio with high total coverage indicates
         the robot is over-cleaning the centre and under-covering edges.
 
-        Returns None when fewer than 10 cells exist (insufficient data), or
-        when the bounding box itself is too small for the edge/centre
-        distinction to be meaningful — v2.8.2: a robot confined to e.g. a
-        1m x 1m patch (heavily fragmented exploration, or genuinely a tiny
-        space) would otherwise have *every* cell within edge_depth_mm of
-        some side, producing a near-1.0 ratio that looks like "excellent
-        edge coverage" but is really just "there is no centre region to
-        compare against". Requiring each bbox dimension to exceed
-        4 * edge_depth_mm guarantees a real interior exists.
-        P3: result is cached by edge_depth_mm and invalidated by update_from_mission;
-        safe to call repeatedly during a mission without re-computing on every pose
-        update. Keyed by edge_depth_mm so different callers with different parameters
-        each get their own correct cached value.
+        Returns the most recently valid default-depth ratio when the current
+        grid lacks enough cells or extent for a meaningful calculation.
+        Non-default depths return None for non-computable grids.
+        Results are cached by edge_depth_mm and invalidated by
+        update_from_mission.
         """
-        # P3: return cached result when available (invalidated by update_from_mission)
         cached = self._edge_ratio_cache.get(edge_depth_mm)
         if cached is not None:
             return cached
+        last_valid = (
+            self._last_valid_edge_coverage_ratio
+            if edge_depth_mm == 300.0
+            else None
+        )
         if len(self._cells) < 10:
-            return None
+            return last_valid
         bbox = self.bounding_box_mm()
         if bbox is None:
-            return None
+            return last_valid
         x_min, x_max, y_min, y_max = bbox
-        # v2.8.2 — bbox too small for the edge/centre distinction to mean
-        # anything (see docstring). Mirrors the "insufficient data" None
-        # return above rather than caching a misleading number.
         _min_span = 4.0 * edge_depth_mm
         if (x_max - x_min) < _min_span or (y_max - y_min) < _min_span:
-            return None
+            return last_valid
         edge_count = 0
         for (gx, gy) in self._cells:
             x_mm, y_mm = _cell_to_mm(gx, gy)
@@ -654,6 +659,8 @@ class GridStore:
                 edge_count += 1
         result = round(edge_count / len(self._cells), 4)
         self._edge_ratio_cache[edge_depth_mm] = result
+        if edge_depth_mm == 300.0:
+            self._last_valid_edge_coverage_ratio = result
         return result
 
     def hotspots(

--- a/custom_components/roomba_plus/icons.json
+++ b/custom_components/roomba_plus/icons.json
@@ -270,6 +270,195 @@
       },
       "part_dirt_bag": {
         "default": "mdi:trash-can-outline"
+      },
+      "total_energy_consumed": {
+        "default": "mdi:lightning-bolt"
+      },
+      "lifetime_completion_rate": {
+        "default": "mdi:percent"
+      },
+      "battery_cycle_count_bms": {
+        "default": "mdi:battery-sync-outline"
+      },
+      "battery_age_days": {
+        "default": "mdi:battery-clock-outline"
+      },
+      "dock_firmware_version": {
+        "default": "mdi:memory"
+      },
+      "wheel_last_cleaned": {
+        "default": "mdi:wheel"
+      },
+      "contact_last_cleaned": {
+        "default": "mdi:connection"
+      },
+      "bin_last_cleaned": {
+        "default": "mdi:trash-can-outline"
+      },
+      "last_mission_team_id": {
+        "default": "mdi:account-group-outline"
+      },
+      "consecutive_mission_anomalies": {
+        "default": "mdi:alert-outline"
+      },
+      "side_brush_wear_rate": {
+        "default": "mdi:broom"
+      },
+      "clean_base_bag_wear_rate": {
+        "default": "mdi:trash-can-outline"
+      },
+      "side_brush_days_until_due": {
+        "default": "mdi:broom"
+      },
+      "clean_base_bag_days_until_due": {
+        "default": "mdi:trash-can-outline"
+      },
+      "nav_landmark_quality": {
+        "default": "mdi:map-marker-check-outline"
+      },
+      "nav_good_landmarks": {
+        "default": "mdi:map-marker-check"
+      },
+      "optical_dirt_detections": {
+        "default": "mdi:eye"
+      },
+      "piezo_dirt_detections": {
+        "default": "mdi:waveform"
+      },
+      "nav_orientations": {
+        "default": "mdi:compass-outline"
+      },
+      "dock_contact_chatters": {
+        "default": "mdi:connection"
+      },
+      "dock_knockoffs": {
+        "default": "mdi:alert-outline"
+      },
+      "dock_charge_aborts": {
+        "default": "mdi:battery-alert"
+      },
+      "optimal_clean_window": {
+        "default": "mdi:calendar-clock-outline"
+      },
+      "firmware_version": {
+        "default": "mdi:chip"
+      },
+      "integration_health": {
+        "default": "mdi:heart-pulse"
+      },
+      "reset_diagnostics_summary": {
+        "default": "mdi:restart-alert"
+      },
+      "recent_edge_coverage_ratio": {
+        "default": "mdi:border-outside"
+      },
+      "mission_progress": {
+        "default": "mdi:progress-clock"
+      },
+      "map_learning": {
+        "default": "mdi:map-check"
+      },
+      "zone_summary": {
+        "default": "mdi:map-marker-multiple-outline"
+      },
+      "rooms_overdue": {
+        "default": "mdi:home-alert-outline"
+      },
+      "dirt_weather_correlation": {
+        "default": "mdi:chart-scatter-plot"
+      },
+      "last_mission_summary": {
+        "default": "mdi:clipboard-text-clock-outline"
+      },
+      "room_cleaning_history": {
+        "default": "mdi:history"
+      },
+      "room_areas": {
+        "default": "mdi:floor-plan"
+      },
+      "room_accessibility_scores": {
+        "default": "mdi:door-open"
+      },
+      "relocalisation_rate": {
+        "default": "mdi:map-marker-path"
+      },
+      "cleaning_performance": {
+        "default": "mdi:speedometer"
+      },
+      "cleaning_analytics_30d": {
+        "default": "mdi:chart-box-outline"
+      },
+      "wifi_health": {
+        "default": "mdi:wifi-check"
+      },
+      "event_counts_30d": {
+        "default": "mdi:counter"
+      },
+      "robot_health_score": {
+        "default": "mdi:heart-pulse"
+      },
+      "health_score_trend": {
+        "default": "mdi:trending-up"
+      },
+      "wifi_last_channel": {
+        "default": "mdi:wifi-settings"
+      },
+      "wifi_channel_stability": {
+        "default": "mdi:wifi-alert"
+      },
+      "missions_per_charge": {
+        "default": "mdi:battery-charging"
+      },
+      "prime_mission_event": {
+        "default": "mdi:timeline-text-outline"
+      },
+      "prime_connection_health": {
+        "default": "mdi:lan-connect"
+      },
+      "prime_cleaning_mode": {
+        "default": "mdi:auto-mode"
+      },
+      "prime_detected_pad": {
+        "default": "mdi:square-rounded-outline"
+      },
+      "prime_dock_status": {
+        "default": "mdi:dock-window"
+      },
+      "prime_pad_wash_status": {
+        "default": "mdi:wiper-wash"
+      },
+      "prime_pad_dry_status": {
+        "default": "mdi:weather-sunny"
+      },
+      "prime_suction_level": {
+        "default": "mdi:fan-speed-3"
+      },
+      "prime_runtime_hours": {
+        "default": "mdi:timer-outline"
+      },
+      "prime_firmware_version": {
+        "default": "mdi:chip"
+      },
+      "prime_charge_cycles_ok": {
+        "default": "mdi:battery-check"
+      },
+      "prime_charge_cycles_error": {
+        "default": "mdi:battery-alert"
+      },
+      "prime_system_uptime": {
+        "default": "mdi:clock-outline"
+      },
+      "prime_navigation_resets": {
+        "default": "mdi:compass-off-outline"
+      },
+      "prime_serial_number": {
+        "default": "mdi:identifier"
+      },
+      "prime_consumable_part": {
+        "default": "mdi:wrench-outline"
+      },
+      "region_last_cleaned": {
+        "default": "mdi:calendar-check-outline"
       }
     },
     "button": {
@@ -320,6 +509,24 @@
       },
       "reset_clean_base_bag": {
         "default": "mdi:trash-can-outline"
+      },
+      "prime_favorite": {
+        "default": "mdi:star-outline"
+      },
+      "prime_empty_bin": {
+        "default": "mdi:delete-sweep-outline"
+      },
+      "prime_wash_pad": {
+        "default": "mdi:wiper-wash"
+      },
+      "prime_stop_pad_dry": {
+        "default": "mdi:stop-circle-outline"
+      },
+      "prime_start_pad_dry": {
+        "default": "mdi:weather-sunny"
+      },
+      "prime_locate": {
+        "default": "mdi:map-marker-radius-outline"
       }
     },
     "select": {
@@ -343,6 +550,33 @@
       },
       "carpet_boost_select": {
         "default": "mdi:carpet"
+      },
+      "prime_suction_level": {
+        "default": "mdi:fan-speed-3"
+      },
+      "prime_pad_wetness": {
+        "default": "mdi:water-percent"
+      },
+      "prime_pad_dry_duration": {
+        "default": "mdi:timer-outline"
+      },
+      "prime_pad_wash_return": {
+        "default": "mdi:wiper-wash"
+      },
+      "prime_pad_wash_area_interval": {
+        "default": "mdi:vector-square"
+      },
+      "prime_pad_wash_time_interval": {
+        "default": "mdi:timer-outline"
+      },
+      "prime_pad_wash_heat": {
+        "default": "mdi:thermometer-water"
+      },
+      "prime_autoevac_frequency": {
+        "default": "mdi:delete-empty"
+      },
+      "smart_zones_need_naming": {
+        "default": "mdi:map-marker-question-outline"
       }
     },
     "switch": {
@@ -354,6 +588,45 @@
       },
       "schedule_hold": {
         "default": "mdi:calendar-lock-outline"
+      },
+      "child_lock": {
+        "default": "mdi:lock"
+      },
+      "eco_charge": {
+        "default": "mdi:battery-charging"
+      },
+      "gentle_mode": {
+        "default": "mdi:feather"
+      },
+      "prime_carpet_boost": {
+        "default": "mdi:carpet"
+      },
+      "prime_child_lock": {
+        "default": "mdi:lock"
+      },
+      "prime_eco_charge": {
+        "default": "mdi:battery-charging"
+      },
+      "prime_pad_wash_allowed": {
+        "default": "mdi:wiper-wash"
+      },
+      "prime_pad_dry_allowed": {
+        "default": "mdi:weather-sunny"
+      },
+      "prime_two_pass": {
+        "default": "mdi:repeat"
+      },
+      "prime_vac_high": {
+        "default": "mdi:fan-speed-3"
+      },
+      "prime_pad_dry": {
+        "default": "mdi:hair-dryer"
+      },
+      "prime_schedule": {
+        "default": "mdi:calendar-clock"
+      },
+      "prime_not_connected": {
+        "default": "mdi:lan-disconnect"
       }
     },
     "image": {
@@ -362,11 +635,101 @@
       },
       "rooms_map": {
         "default": "mdi:floor-plan"
+      },
+      "raw_map": {
+        "default": "mdi:map-outline"
+      },
+      "map": {
+        "default": "mdi:map-marker-path"
+      },
+      "cleaning_map": {
+        "default": "mdi:map-marker-path"
+      },
+      "zones_need_naming": {
+        "default": "mdi:map-marker-question-outline"
       }
     },
     "binary_sensor": {
       "mission_active": {
         "default": "mdi:robot-vacuum"
+      },
+      "bin_full": {
+        "default": "mdi:delete-alert"
+      },
+      "bin_present": {
+        "default": "mdi:delete-outline"
+      },
+      "connected": {
+        "default": "mdi:lan-connect"
+      },
+      "mop_ready": {
+        "default": "mdi:wiper-wash"
+      },
+      "mop_tank_present": {
+        "default": "mdi:water-check"
+      },
+      "mop_lid_closed": {
+        "default": "mdi:door-closed"
+      },
+      "map_saving": {
+        "default": "mdi:map-outline"
+      },
+      "maintenance_due": {
+        "default": "mdi:tools"
+      },
+      "start_blocked": {
+        "default": "mdi:alert-circle-outline"
+      },
+      "schedule_hold_active": {
+        "default": "mdi:calendar-lock-outline"
+      },
+      "mop_lid_open": {
+        "default": "mdi:door-open"
+      },
+      "mop_tank_present_direct": {
+        "default": "mdi:water-check"
+      },
+      "mid_mission_recharge": {
+        "default": "mdi:battery-charging"
+      },
+      "cloud_connected": {
+        "default": "mdi:cloud-check-outline"
+      },
+      "mqtt_stale": {
+        "default": "mdi:cloud-alert"
+      },
+      "firmware_updated": {
+        "default": "mdi:package-up"
+      },
+      "layout_change_detected": {
+        "default": "mdi:floor-plan"
+      },
+      "prime_dock_error": {
+        "default": "mdi:alert-circle-outline"
+      },
+      "prime_start_blocked": {
+        "default": "mdi:alert-circle-outline"
+      },
+      "demand_clean_blocked": {
+        "default": "mdi:play-box-lock"
+      }
+    },
+    "device_tracker": {
+      "position": {
+        "default": "mdi:map-marker"
+      }
+    },
+    "calendar": {
+      "schedule": {
+        "default": "mdi:calendar-clock"
+      },
+      "calendar_room_not_found": {
+        "default": "mdi:calendar-remove-outline"
+      }
+    },
+    "todo": {
+      "maintenance": {
+        "default": "mdi:clipboard-list-outline"
       }
     }
   }

--- a/custom_components/roomba_plus/image.py
+++ b/custom_components/roomba_plus/image.py
@@ -148,8 +148,10 @@ def _mission_checkpoint_storage_key(entry_id: str) -> str:
     return f"roomba_plus_map_checkpoint_{entry_id}"
 
 
-# v2.6.3 E — dispatcher signal fired by RoombaMapImage after GridStore update.
-# RoombaCoverageImage listens to bump image_last_updated so the frontend re-fetches.
+# Fired by RoombaMapImage._refresh_terminal_mission_images() at every
+# terminal mission, including pose-less ones GridStore never sees — the
+# only way RoombaRoomsImage (new_state_filter always False) ever learns a
+# mission ended.
 _SIGNAL_COVERAGE_UPDATED = "roomba_plus_coverage_updated_{}"
 
 
@@ -1272,6 +1274,7 @@ class RoombaMapImage(IRobotEntity, ImageEntity):
         # resolves it (resume or salvage) — see _consume_pending_checkpoint().
         self._mission_checkpoint_mssn_strt_tm: int = 0
         self._pending_checkpoint: dict[str, Any] | None = None
+        self._last_terminal_mission_key: str | None = None
 
         # Initial timestamp so frontend knows an image exists from the start
         self._attr_image_last_updated: dt_datetime = dt_util.now(datetime.timezone.utc)
@@ -1926,6 +1929,39 @@ class RoombaMapImage(IRobotEntity, ImageEntity):
         self.schedule_update_ha_state()
 
     # ── Private helpers ───────────────────────────────────────────────────────
+    def _refresh_terminal_mission_images(self) -> None:
+        state = getattr(self, "vacuum_state", {})
+        mission_status = state.get("cleanMissionStatus") or {}
+        mssn_strt_tm = mission_status.get("mssnStrtTm") or getattr(
+            self, "_mission_checkpoint_mssn_strt_tm", 0
+        )
+        if mssn_strt_tm:
+            mission_key: str | None = f"mssnStrtTm:{mssn_strt_tm}"
+        else:
+            mission_number = (state.get("bbmssn") or {}).get("nMssn")
+            mission_start = getattr(self, "_mission_start_ts", None)
+            mission_key = (
+                f"nMssn:{mission_number}"
+                if mission_number
+                else f"started:{mission_start}" if mission_start else None
+            )
+        if (
+            mission_key is not None
+            and mission_key == getattr(self, "_last_terminal_mission_key", None)
+        ):
+            return
+        if mission_key is not None:
+            self._last_terminal_mission_key = mission_key
+        self._attr_image_last_updated = dt_util.now(datetime.timezone.utc)
+        self._cache = None
+        if self._config_entry is not None:
+            asyncio.run_coroutine_threadsafe(
+                _async_send_coverage_signal(
+                    self.hass, self._config_entry.entry_id
+                ),
+                self.hass.loop,
+            )
+
 
     def _handle_pose(self, pose: dict[str, Any]) -> None:
         """Add pose point and signal frontend to re-fetch image.
@@ -2229,6 +2265,7 @@ class RoombaMapImage(IRobotEntity, ImageEntity):
                 self._async_clear_mission_checkpoint(), loop
             )
 
+        self._refresh_terminal_mission_images()
         if not self._mission_points:
             return
 
@@ -2566,13 +2603,6 @@ class RoombaMapImage(IRobotEntity, ImageEntity):
                 _LOGGER.debug(
                     "GridStore: updated from mission — %d pose pts, %d stuck pts",
                     len(self._mission_points), len(self._stuck_mission_points),
-                )
-                # v2.6.3 E — notify RoombaCoverageImage so it bumps its
-                # image_last_updated timestamp and the frontend re-fetches.
-                _eid = self._config_entry.entry_id
-                asyncio.run_coroutine_threadsafe(
-                    _async_send_coverage_signal(self.hass, _eid),
-                    loop,
                 )
 
         self._mission_points = []
@@ -3081,6 +3111,22 @@ class RoombaRoomsImage(IRobotEntity, ImageEntity):
         data = self._config_entry.runtime_data
         if data.umf_aligner and data.umf_aligner.room_polygons_umf:
             await self.hass.async_add_executor_job(self._render_rooms_png)
+
+        from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+        @callback
+        def _on_mission_images_updated() -> None:
+            self._attr_image_last_updated = dt_util.now(datetime.timezone.utc)
+            self._cache = None
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                _SIGNAL_COVERAGE_UPDATED.format(self._config_entry.entry_id),
+                _on_mission_images_updated,
+            )
+        )
 
     def new_state_filter(self, new_state: dict[str, Any]) -> bool:
         return False  # Cloud entity — no MQTT updates

--- a/custom_components/roomba_plus/mission_store.py
+++ b/custom_components/roomba_plus/mission_store.py
@@ -13,8 +13,8 @@ https://github.com/tonylofgren/aurora-smart-home
 from __future__ import annotations
 
 import importlib
-
 import logging
+import re
 import statistics
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -32,6 +32,17 @@ _LOGGER = logging.getLogger(__name__)
 STORAGE_KEY_PREFIX = "roomba_plus_missions"
 STORAGE_VERSION = 1
 MAX_RECORDS = 365
+
+_SEGMENT_SUFFIX_RE = re.compile(r"_r\d+$")
+# Replay pulses (stale MQTT re-delivery of a terminal event) arrive within
+# seconds of the terminal record; a genuine 980/900-series multi-recharge
+# segment resume happens after minutes of charging. Mirrors callbacks.py's
+# _CLOUD_CATCHUP_MISSION_MATCH_SEC (120 s).
+_MISSION_REPLAY_MATCH_SEC = 120
+
+_TERMINAL_REPLAY_IMMUTABLE_FIELDS = frozenset({
+    "id", "started_at", "ended_at", "duration_min", "initiator", "result",
+})
 
 
 class BackfillResult(NamedTuple):
@@ -229,6 +240,70 @@ class MissionStore:
             self._record_ids.add(record["id"])
         self._trim()
 
+    def update_terminal_fields(self, mission_id: str, incoming: dict[str, Any]) -> bool:
+        """Merge a replay/enrichment pulse into mission_id's existing
+        terminal record, in place.
+
+        A same-id append with a fresh ended_at is not always a genuine
+        multi-recharge segment (see async_append above): once a record's
+        own result is already terminal, a later call for the same base id
+        is the mission replaying or self-enriching post-completion, not a
+        new segment — duration_min, initiator, started_at, ended_at, id
+        and result are exactly what a stale replay's re-derived wall-clock
+        would corrupt, so only additive fields are merged.
+
+        Returns True if a terminal record was found and merged into
+        (caller must not also call async_append); False if no record for
+        this id exists yet, the matching record's own result is not yet
+        terminal (still-completing multi-recharge segment — caller falls
+        back to the normal async_append segment logic), or the terminal
+        record's ended_at is far enough from the incoming record that
+        this is a genuine later recharge segment rather than a replay.
+        """
+        for existing in reversed(self._records):
+            if self.base_mission_id(existing.get("id")) != mission_id:
+                continue
+            if not self.is_terminal_result(existing.get("result")):
+                continue
+            if not self._is_replay_window(existing, incoming):
+                continue
+            for field, value in incoming.items():
+                if (
+                    field in _TERMINAL_REPLAY_IMMUTABLE_FIELDS
+                    or field == "npicks_delta"
+                    or value is None
+                ):
+                    continue
+                if existing.get(field) is None or (
+                    field == "zones" and not existing.get(field)
+                ):
+                    existing[field] = value
+            incoming_npicks = incoming.get("npicks_delta") or 0
+            if incoming_npicks > (existing.get("npicks_delta") or 0):
+                existing["npicks_delta"] = incoming_npicks
+            return True
+        return False
+
+    @staticmethod
+    def _is_replay_window(existing: dict[str, Any], incoming: dict[str, Any]) -> bool:
+        """True when incoming is a re-delivery of existing's terminal event
+        rather than a genuine later recharge segment: a replay arrives
+        within MQTT re-delivery latency of the terminal record, while a
+        real segment resume happens after minutes of charging.
+        """
+        if not isinstance(incoming.get("ended_at"), str):
+            return False
+        if not isinstance(existing.get("ended_at"), str):
+            return False
+        existing_dt = dt_util.parse_datetime(existing["ended_at"])
+        incoming_dt = dt_util.parse_datetime(incoming["ended_at"])
+        if existing_dt is None or incoming_dt is None:
+            return False
+        return (
+            abs((incoming_dt - existing_dt).total_seconds())
+            <= _MISSION_REPLAY_MATCH_SEC
+        )
+
     def append_validated(self, record: dict[str, Any]) -> bool:
         """Append with FULL-history id dedup + MAX_RECORDS trim.
 
@@ -389,6 +464,30 @@ class MissionStore:
     ERROR_RESULTS: frozenset[str] = frozenset({
         "error", "stuck", "stuck_and_resumed", "stuck_and_abandoned"
     })
+
+    @staticmethod
+    def is_terminal_result(result: Any) -> bool:
+        """True once a mission has a settled result.
+
+        Cloud import persists ``unknown`` for unrecognised but completed
+        vendor outcomes; it is settled too. Only the explicit in-progress
+        placeholder remains eligible for normal multi-segment append logic.
+        """
+        return (
+            isinstance(result, str)
+            and bool(result)
+            and result != "in_progress"
+        )
+
+    @staticmethod
+    def base_mission_id(record_id: Any) -> str:
+        """Strip a trailing multi-recharge-segment "_rN" suffix (see
+        async_append), returning the id every segment of one physical
+        mission shares.
+        """
+        if not isinstance(record_id, str):
+            return ""
+        return _SEGMENT_SUFFIX_RE.sub("", record_id)
 
     def query(
         self,
@@ -1243,10 +1342,18 @@ class MissionStore:
         return round(max(0.0, rate), 2)
 
     @staticmethod
-    def _merge_cloud_fields(local: dict[str, Any], cloud: dict[str, Any]) -> bool:
+    def _merge_cloud_fields(
+        local: dict[str, Any],
+        cloud: dict[str, Any],
+        allow_result_rewrite: bool = True,
+    ) -> bool:
         """Copy missing analytics fields from a cloud record into a local record.
 
         Only copies when the local field is absent or None — never overwrites.
+
+        allow_result_rewrite=False freezes a settled result against the
+        B1/B1-EXT corrections below — used when the local record is already
+        terminal and nothing may rewrite its identity.
 
         B1 — error 224 result correction: when the cloud record reveals
         pauseId=224 and the local result is 'stuck', correct the result to
@@ -1284,11 +1391,14 @@ class MissionStore:
         Returns True if any field was written.
         """
         wrote = False
+        already_corrected = bool(local.get("result_corrected_from_cloud"))
+        rewrite_allowed = allow_result_rewrite and not already_corrected
 
         # B1 — error 224 result correction (before generic scalar merge).
         pause_id = int(cloud.get("pauseId", 0) or 0)
-        if pause_id == 224 and local.get("result") == "stuck":
+        if rewrite_allowed and pause_id == 224 and local.get("result") == "stuck":
             local["result"] = "error"
+            local["result_corrected_from_cloud"] = True
             if local.get("error_code") is None:
                 local["error_code"] = 224
             wrote = True
@@ -1298,14 +1408,16 @@ class MissionStore:
         done_raw = (cloud.get("done_raw") or "").strip()
         local_result = local.get("result")
 
-        if done == "bat" and local_result in ("completed", "stuck_and_resumed"):
+        if rewrite_allowed and done == "bat" and local_result in ("completed", "stuck_and_resumed"):
             local["result"] = "error"
+            local["result_corrected_from_cloud"] = True
             if local.get("error_code") is None and pause_id > 0:
                 local["error_code"] = pause_id
             wrote = True
 
-        elif done_raw == "usrEnd" and local_result in ("completed", "stuck_and_resumed"):
+        elif rewrite_allowed and done_raw == "usrEnd" and local_result in ("completed", "stuck_and_resumed"):
             local["result"] = "cancelled"
+            local["result_corrected_from_cloud"] = True
             wrote = True
 
         for field in _CLOUD_MERGE_SCALAR:
@@ -1667,6 +1779,16 @@ class MissionStore:
                 delta_start = float("inf")
 
             # Always merge analytics fields regardless of timestamp delta.
+            # A settled result is frozen: the B1/B1-EXT corrections may only
+            # apply to records that are not yet terminal (see
+            # update_terminal_fields' freeze contract).
+            # Result corrections (B1/B1-EXT) are EXEMPT from the terminal
+            # freeze by design: the local MQTT classification is provably
+            # wrong (battery death / user cancel / 224-abort) and the cloud
+            # is the first authoritative truth — a correction applies once
+            # per record. The freeze protects timing/identity fields below;
+            # _merge_cloud_fields' result_corrected_from_cloud marker makes
+            # repeat mutation impossible (no error<->cancelled oscillation).
             merge_wrote = self._merge_cloud_fields(local, best_cr)
 
             # area_sqft is the canonical local name; "sqft" above is the
@@ -1685,8 +1807,21 @@ class MissionStore:
             if merge_wrote or area_wrote:
                 enriched += 1
 
+            terminal = self.is_terminal_result(local.get("result"))
+            # 980/900-series firmware resets mssnStrtTm to 0 at mission end:
+            # the local record may be stuck with started_at == ended_at and
+            # duration_min == 0 forever. That degenerate signature is exactly
+            # what the cloud correction below exists for, so it stays eligible
+            # even once terminal.
+            degenerate_980 = (
+                local.get("started_at") == local.get("ended_at")
+                or not local.get("duration_min")
+            )
+
             # Only correct timestamps when they differ meaningfully (> 5 min).
             if delta_start < 300:
+                continue
+            if terminal and not degenerate_980:
                 continue
 
             new_duration = max(0, round(

--- a/custom_components/roomba_plus/robot_profile_store.py
+++ b/custom_components/roomba_plus/robot_profile_store.py
@@ -310,6 +310,11 @@ class RobotProfileStore:
     lifetime_sqft_last_value: float | None = None
     lifetime_sqft_last_changed_at: str | None = None
 
+    # F12e — floor for total_energy_consumed (TOTAL_INCREASING contract):
+    # estCap/cycle-count can shift downward between polls, so the raw
+    # computed kWh alone isn't safe to report directly.
+    lifetime_energy_kwh_high_water: float = 0.0
+
     # ── Persistence ───────────────────────────────────────────────────────────
 
     async def async_load(self, hass: HomeAssistant, entry_id: str) -> None:
@@ -403,6 +408,8 @@ class RobotProfileStore:
             lsv = data.get("lifetime_sqft_last_value")
             self.lifetime_sqft_last_value = float(lsv) if lsv is not None else None
             self.lifetime_sqft_last_changed_at = data.get("lifetime_sqft_last_changed_at")
+            lekw = data.get("lifetime_energy_kwh_high_water")
+            self.lifetime_energy_kwh_high_water = float(lekw) if lekw is not None else 0.0
 
             _LOGGER.debug(
                 "RobotProfileStore: loaded — rooms=%d coverage_baseline=%s",
@@ -455,6 +462,7 @@ class RobotProfileStore:
             "health_score_history": self.health_score_history,
             "lifetime_sqft_last_value": self.lifetime_sqft_last_value,
             "lifetime_sqft_last_changed_at": self.lifetime_sqft_last_changed_at,
+            "lifetime_energy_kwh_high_water": self.lifetime_energy_kwh_high_water,
         })
 
     async def async_reset(self, hass: HomeAssistant, entry_id: str) -> None:
@@ -491,6 +499,7 @@ class RobotProfileStore:
         self.health_score_history = []
         self.lifetime_sqft_last_value = None
         self.lifetime_sqft_last_changed_at = None
+        self.lifetime_energy_kwh_high_water = 0.0
         await self.async_save(hass, entry_id)
         _LOGGER.info("RobotProfileStore: reset for entry %s", entry_id)
 
@@ -1074,6 +1083,15 @@ class RobotProfileStore:
         self.lifetime_sqft_last_value = current_sqft
         self.lifetime_sqft_last_changed_at = dt_util.now().isoformat()
         return True
+
+    def update_energy_high_water(self, candidate_kwh: float) -> float:
+        """Floor for total_energy_consumed's TOTAL_INCREASING contract —
+        the raw kWh recomputed from estCap/cycle-count can drop between
+        polls, which would otherwise violate that state_class.
+        """
+        if candidate_kwh > self.lifetime_energy_kwh_high_water:
+            self.lifetime_energy_kwh_high_water = candidate_kwh
+        return self.lifetime_energy_kwh_high_water
 
     @property
     def lifetime_sqft_days_unchanged(self) -> float | None:

--- a/custom_components/roomba_plus/select.py
+++ b/custom_components/roomba_plus/select.py
@@ -262,7 +262,8 @@ async def async_setup_entry(
                         )
                     )
         else:
-            entities.append(SmartZoneSelect(roomba, blid, config_entry))
+            smart_zone_select = SmartZoneSelect(roomba, blid, config_entry)
+            entities.append(smart_zone_select)
 
     # v1.9.0 — Braava Pad Wetness selects
     if "padWetness" in state:

--- a/custom_components/roomba_plus/sensor_cloud.py
+++ b/custom_components/roomba_plus/sensor_cloud.py
@@ -155,7 +155,7 @@ def _raw_completion_rate(records: list[dict[str, Any]]) -> StateType:
     """Return completion rate (%) across the API window records."""
     if not records:
         return None
-    completed = sum(1 for r in records if r.get("done") == "done")
+    completed = sum(1 for r in records if r.get("classified_result") == "completed")
     return round(completed / len(records) * 100, 1)
 
 
@@ -180,46 +180,66 @@ def _raw_dirt_events(records: list[dict[str, Any]]) -> StateType:
     return sum(int(r.get("dirt", 0) or 0) for r in records)
 
 
-def _raw_cloud_last_error_code(records: list[dict[str, Any]]) -> StateType:
-    """Return the pauseId from the most recent failed mission record."""
+def _cloud_last_error_record(records: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Newest failed/stuck record within the entity's 30-day framing.
+
+    `records` is a count-based API window (cloud_api.get_mission_history),
+    not itself bounded to 30 days, so a candidate older than
+    event_counts_30d's own framing is skipped rather than surfaced as if it
+    were recent. Shared by state, timestamp and catalogue attributes so the
+    three never disagree about which error (if any) is current.
+    """
+    cutoff = dt_util.utcnow() - datetime.timedelta(days=30)
     for r in records:
         classified = r.get("classified_result", "")
-        if classified.startswith("error_") or classified == "stuck":
-            pause_id = int(r.get("pauseId", 0) or 0)
-            return pause_id if pause_id > 0 else None
+        if not (classified.startswith("error_") or classified == "stuck"):
+            continue
+        ts = r.get("timestamp")
+        if ts:
+            error_time = datetime.datetime.fromtimestamp(
+                int(ts), tz=datetime.timezone.utc
+            )
+            if error_time < cutoff:
+                continue
+        return r
     return None
+
+
+def _raw_cloud_last_error_code(records: list[dict[str, Any]]) -> StateType:
+    """Return the pauseId from the most recent failed mission record."""
+    r = _cloud_last_error_record(records)
+    if r is None:
+        return None
+    pause_id = int(r.get("pauseId", 0) or 0)
+    return pause_id if pause_id > 0 else None
 
 
 def _raw_cloud_last_error_time(records: list[dict[str, Any]]) -> datetime.datetime | None:
     """Return the end timestamp of the most recent failed mission as a datetime."""
-    for r in records:
-        classified = r.get("classified_result", "")
-        if classified.startswith("error_") or classified == "stuck":
-            ts = r.get("timestamp")
-            if ts:
-                import datetime
-                return datetime.datetime.fromtimestamp(
-                    int(ts), tz=datetime.timezone.utc
-                )
-    return None
+    r = _cloud_last_error_record(records)
+    if r is None:
+        return None
+    ts = r.get("timestamp")
+    if not ts:
+        return None
+    return datetime.datetime.fromtimestamp(int(ts), tz=datetime.timezone.utc)
 
 
 def _raw_cloud_last_error_attrs(records: list[dict[str, Any]]) -> dict[str, Any]:
     """Return ERROR_CATALOGUE label + action for the most recent cloud error."""
     from .const import ERROR_CATALOGUE
-    for r in records:
-        classified = r.get("classified_result", "")
-        if classified.startswith("error_") or classified == "stuck":
-            pause_id = int(r.get("pauseId", 0) or 0)
-            catalogue = ERROR_CATALOGUE.get(pause_id, {})
-            return {
-                "error_code": pause_id or None,
-                "label": catalogue.get("label", ""),
-                "description": catalogue.get("description", ""),
-                "action": catalogue.get("action", ""),
-                "source": "cloud_pauseId",
-            }
-    return {}
+    r = _cloud_last_error_record(records)
+    if r is None:
+        return {}
+    pause_id = int(r.get("pauseId", 0) or 0)
+    catalogue = ERROR_CATALOGUE.get(pause_id, {})
+    return {
+        "error_code": pause_id or None,
+        "label": catalogue.get("label", ""),
+        "description": catalogue.get("description", ""),
+        "action": catalogue.get("action", ""),
+        "source": "cloud_pauseId",
+    }
 
 
 import statistics as _statistics

--- a/custom_components/roomba_plus/sensor_core.py
+++ b/custom_components/roomba_plus/sensor_core.py
@@ -478,6 +478,7 @@ SENSORS: tuple[RoombaSensorDescription, ...] = (
         device_class=SensorDeviceClass.AREA,
         native_unit_of_measurement=UnitOfArea.SQUARE_METERS,
         suggested_display_precision=0,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         entity_category=EntityCategory.DIAGNOSTIC,
         # v2.9.0 (J) — same AREA-ZERO-FIX family as v2.8.2's
         # mission.get("sqft") or None fix in callbacks.py: confirmed on the
@@ -1113,7 +1114,18 @@ SENSORS: tuple[RoombaSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda e: _mission_store_value(
-            e, lambda s: len(s.query(30, result="completed"))
+            e,
+            lambda s: len(
+                {
+                    base
+                    for r in s.query(30, result="completed")
+                    if (base := s.base_mission_id(r.get("id")))
+                }
+            )
+            + sum(
+                1 for r in s.query(30, result="completed")
+                if not s.base_mission_id(r.get("id"))
+            ),
         ),
     ),
     RoombaSensorDescription(
@@ -1651,8 +1663,6 @@ _MISSION_STORE_SENSORS: frozenset[str] = frozenset({
     "stuck_count_30d", "problem_zone",
     "last_error_code", "last_error_at", "last_error_zone",
 })
-
-
 
 class RoombaSensor(IRobotEntity, SensorEntity):
     """A sensor entity for Roomba+, driven by the EntityDescription pattern."""

--- a/custom_components/roomba_plus/sensor_diagnostics.py
+++ b/custom_components/roomba_plus/sensor_diagnostics.py
@@ -318,7 +318,7 @@ class RoombaResetDiagnosticsSensor(IRobotEntity, SensorEntity):
     field presence.
     """
 
-    _attr_translation_key = "reset_diagnostics"
+    _attr_translation_key = "reset_diagnostics_summary"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.MEASUREMENT

--- a/custom_components/roomba_plus/sensor_helpers.py
+++ b/custom_components/roomba_plus/sensor_helpers.py
@@ -130,12 +130,12 @@ def recent_pause_reasons(entity: "IRobotEntity") -> list[int]:
     return outer or nested
 
 
-def _error_value(entity: "IRobotEntity") -> str:
+def _error_value(entity: "IRobotEntity") -> str | None:
     """Error label — suppressed when the robot is docked/idle after a mission.
 
     cleanMissionStatus.error persists across missions: the firmware does not
     reset it to 0 when the robot docks after a failure. Showing the stale error
-    while the robot charges would be misleading, so we return "None" whenever
+    while the robot charges would be misleading, so we return None whenever
     cycle is "none" (no active or queued mission) and phase indicates rest.
     """
     status = entity.clean_mission_status
@@ -145,9 +145,10 @@ def _error_value(entity: "IRobotEntity") -> str:
 
     # No active mission and robot is resting — suppress stale error.
     if cycle == "none" and phase in ("charge", "stop", "idle", ""):
-        return "None"
+        return None
 
-    return ERROR_CODE_LABELS.get(error, entity.vacuum.error_message or "None")
+    label = ERROR_CODE_LABELS.get(error, entity.vacuum.error_message or None)
+    return label if label and label != "None" else None
 
 
 #: How long a robot may go quiet before the status says so rather than
@@ -494,8 +495,16 @@ def _presence_utilisation(entity: "IRobotEntity", days: int) -> StateType:
     opportunities = _presence_opportunities(entity, days) or 0
     if opportunities == 0:
         return 0.0
-    used = sum(1 for w in windows if w.resulted_in_clean)
-    return round(used / opportunities * 100, 1)
+    recent = store.query(30, result="completed")
+    avg_duration = (
+        sum(r["duration_min"] for r in recent) / len(recent)
+        if recent else 45
+    )
+    used = sum(
+        1 for w in windows
+        if w.duration_min >= avg_duration and w.resulted_in_clean
+    )
+    return round(min(used / opportunities * 100, 100.0), 1)
 
 
 def _next_likely_clean_window(entity: "IRobotEntity") -> StateType | datetime.datetime:
@@ -1209,6 +1218,10 @@ def _total_energy_consumed_kwh(entity: "IRobotEntity") -> StateType:
     Cycle count is also chemistry-aware: uses nNimhChrg when NiMH is detected
     (nNimhChrg > 0), nLithChrg otherwise — important when the user has replaced
     the OEM Li-ion pack with NiMH aftermarket (nLithChrg stays at the OEM count).
+
+    Clamped to a persisted high-water mark: estCap/cycle-count can shift
+    downward between polls, which would otherwise violate this sensor's
+    declared TOTAL_INCREASING state_class.
     """
     actual_mah = _estcap_to_mah(entity)
     if actual_mah is None:
@@ -1222,7 +1235,17 @@ def _total_energy_consumed_kwh(entity: "IRobotEntity") -> StateType:
         return None
     profile = entity._config_entry.runtime_data.robot_profile
     voltage = profile.battery_voltage if profile is not None else 14.8
-    return round(actual_mah * voltage * int(cycles) / 1_000_000, 3)
+    raw_kwh = round(actual_mah * voltage * int(cycles) / 1_000_000, 3)
+
+    rps = getattr(entity._config_entry.runtime_data, "robot_profile_store", None)
+    if rps is None:
+        return raw_kwh
+    # value_fn stays side-effect-free: the high-water mark is advanced at
+    # mission end (callbacks._async_update_robot_profile_store), never on
+    # a sensor read. Reading the stored floor keeps the TOTAL_INCREASING
+    # contract across HA restarts.
+    stored_floor = cast(float, rps.lifetime_energy_kwh_high_water)
+    return max(raw_kwh, stored_floor)
 
 
 def _estimated_battery_eol(entity: "IRobotEntity") -> StateType:

--- a/custom_components/roomba_plus/sensor_prime.py
+++ b/custom_components/roomba_plus/sensor_prime.py
@@ -1371,10 +1371,10 @@ class PrimeErrorSensor(_PrimeCurrentStateSensorBase):
             return None
         # Same rule Classic uses -- see this class's own docstring.
         if (status.cycle or "none") == "none" and (status.phase or "") in ("charge", "stop", "idle", ""):
-            return "None"
+            return None
         code = status.error or 0
         if code == 0:
-            return "None"
+            return None
         return f"Error {code}"
 
     @property

--- a/custom_components/roomba_plus/sensor_rooms.py
+++ b/custom_components/roomba_plus/sensor_rooms.py
@@ -39,7 +39,7 @@ class RoombaEdgeCoverageSensor(IRobotEntity, SensorEntity):
     F12d (v2.4.0) — a low ratio with high total coverage indicates the robot
     is over-cleaning the centre and under-covering room edges/walls.
 
-    State: float 0.0–1.0 (edge cells / total cells), or None when < 10 cells.
+    State: float 0.0–1.0 from the current grid or its last valid measurement.
     entity_category: DIAGNOSTIC.
     Unit: None (dimensionless ratio).
     """
@@ -61,7 +61,7 @@ class RoombaEdgeCoverageSensor(IRobotEntity, SensorEntity):
 
     @property
     def native_value(self) -> float | None:
-        """Return edge_coverage_ratio from GridStore, or None when insufficient data."""
+        """Return the current or retained edge_coverage_ratio from GridStore."""
         gs = self._config_entry.runtime_data.grid_store
         if gs is None:
             return None

--- a/custom_components/roomba_plus/strings.json
+++ b/custom_components/roomba_plus/strings.json
@@ -888,9 +888,6 @@
       "last_mission_team_id": {
         "name": "Missions – Last mission team ID"
       },
-      "reset_diagnostics": {
-        "name": "Reset diagnostics"
-      },
       "health_score_trend": {
         "name": "Health score trend",
         "state": {
@@ -1290,6 +1287,9 @@
       },
       "last_charge": {
         "name": "Last charged"
+      },
+      "reset_diagnostics_summary": {
+        "name": "Diagnostics reset counters"
       }
     },
     "device_tracker": {

--- a/custom_components/roomba_plus/translations/de.json
+++ b/custom_components/roomba_plus/translations/de.json
@@ -886,9 +886,6 @@
       "last_mission_team_id": {
         "name": "Missionen – Team-ID der letzten Mission"
       },
-      "reset_diagnostics": {
-        "name": "Reset-Diagnostik"
-      },
       "health_score_trend": {
         "name": "Gesundheits-Score-Trend",
         "state": {
@@ -1288,6 +1285,9 @@
       },
       "last_charge": {
         "name": "Zuletzt geladen"
+      },
+      "reset_diagnostics_summary": {
+        "name": "Reset-Diagnostik-Zähler"
       }
     },
     "binary_sensor": {

--- a/custom_components/roomba_plus/translations/en.json
+++ b/custom_components/roomba_plus/translations/en.json
@@ -886,9 +886,6 @@
       "last_mission_team_id": {
         "name": "Missions – Last mission team ID"
       },
-      "reset_diagnostics": {
-        "name": "Reset diagnostics"
-      },
       "health_score_trend": {
         "name": "Health score trend",
         "state": {
@@ -1288,6 +1285,9 @@
       },
       "last_charge": {
         "name": "Last charged"
+      },
+      "reset_diagnostics_summary": {
+        "name": "Diagnostics reset counters"
       }
     },
     "binary_sensor": {

--- a/custom_components/roomba_plus/translations/es.json
+++ b/custom_components/roomba_plus/translations/es.json
@@ -886,9 +886,6 @@
       "last_mission_team_id": {
         "name": "Misiones – ID de equipo de la última misión"
       },
-      "reset_diagnostics": {
-        "name": "Diagnóstico de reinicios"
-      },
       "health_score_trend": {
         "name": "Tendencia de puntuación de salud",
         "state": {
@@ -1288,6 +1285,9 @@
       },
       "last_charge": {
         "name": "Última carga"
+      },
+      "reset_diagnostics_summary": {
+        "name": "Contadores de reseteo de diagnóstico"
       }
     },
     "binary_sensor": {

--- a/custom_components/roomba_plus/translations/fr.json
+++ b/custom_components/roomba_plus/translations/fr.json
@@ -886,9 +886,6 @@
       "last_mission_team_id": {
         "name": "Missions – ID d'équipe de la dernière mission"
       },
-      "reset_diagnostics": {
-        "name": "Diagnostic des réinitialisations"
-      },
       "health_score_trend": {
         "name": "Tendance du score de santé",
         "state": {
@@ -1288,6 +1285,9 @@
       },
       "last_charge": {
         "name": "Dernière charge"
+      },
+      "reset_diagnostics_summary": {
+        "name": "Compteurs de réinitialisation du diagnostic"
       }
     },
     "binary_sensor": {

--- a/custom_components/roomba_plus/translations/it.json
+++ b/custom_components/roomba_plus/translations/it.json
@@ -886,9 +886,6 @@
       "last_mission_team_id": {
         "name": "Missioni – ID team dell'ultima missione"
       },
-      "reset_diagnostics": {
-        "name": "Diagnostica dei reset"
-      },
       "health_score_trend": {
         "name": "Tendenza punteggio salute",
         "state": {
@@ -1288,6 +1285,9 @@
       },
       "last_charge": {
         "name": "Ultima ricarica"
+      },
+      "reset_diagnostics_summary": {
+        "name": "Contatori di reset diagnostici"
       }
     },
     "binary_sensor": {

--- a/custom_components/roomba_plus/translations/nl.json
+++ b/custom_components/roomba_plus/translations/nl.json
@@ -886,9 +886,6 @@
       "last_mission_team_id": {
         "name": "Missies – Team-ID van laatste missie"
       },
-      "reset_diagnostics": {
-        "name": "Reset-diagnostiek"
-      },
       "health_score_trend": {
         "name": "Gezondheidsscore-trend",
         "state": {
@@ -1288,6 +1285,9 @@
       },
       "last_charge": {
         "name": "Laatst opgeladen"
+      },
+      "reset_diagnostics_summary": {
+        "name": "Diagnostische reset-tellers"
       }
     },
     "binary_sensor": {

--- a/custom_components/roomba_plus/translations/pl.json
+++ b/custom_components/roomba_plus/translations/pl.json
@@ -886,9 +886,6 @@
       "last_mission_team_id": {
         "name": "Misje – ID zespołu ostatniej misji"
       },
-      "reset_diagnostics": {
-        "name": "Resetuj diagnostykę"
-      },
       "health_score_trend": {
         "name": "Trend kondycji robota",
         "state": {
@@ -1288,6 +1285,9 @@
       },
       "last_charge": {
         "name": "Ostatnie ładowanie"
+      },
+      "reset_diagnostics_summary": {
+        "name": "Liczniki resetów diagnostycznych"
       }
     },
     "binary_sensor": {

--- a/custom_components/roomba_plus/translations/pt.json
+++ b/custom_components/roomba_plus/translations/pt.json
@@ -886,9 +886,6 @@
       "last_mission_team_id": {
         "name": "Missões – ID da equipa da última missão"
       },
-      "reset_diagnostics": {
-        "name": "Diagnóstico de reinícios"
-      },
       "health_score_trend": {
         "name": "Tendência da pontuação de saúde",
         "state": {
@@ -1288,6 +1285,9 @@
       },
       "last_charge": {
         "name": "Último carregamento"
+      },
+      "reset_diagnostics_summary": {
+        "name": "Contadores de reinício de diagnóstico"
       }
     },
     "binary_sensor": {

--- a/tests/test_button_prime.py
+++ b/tests/test_button_prime.py
@@ -896,6 +896,41 @@ class TestBothFavouritePathsFilterByRobot:
         )
 
 
+class TestInternalFavouritesAreHidden:
+    """Firmware-internal favourites like
+    `_mission_init_config_9A37307A20804F0CABE9B6011B82DDBE` are not
+    something a user created in the app and must not appear as a button
+    or in the `favorites` attribute -- the ownership filter only ever
+    checked which robot a favourite belongs to, never whether it was a
+    real one."""
+
+    def test_build_prime_favorite_buttons_excludes_internal_name(self):
+        from custom_components.roomba_plus.button_prime import (
+            build_prime_favorite_buttons,
+        )
+
+        entry = _entry([
+            _favorite("f1", "Kitchen"),
+            _favorite("f2", "_mission_init_config_ABCDEF"),
+        ])
+        buttons = build_prime_favorite_buttons(entry)
+
+        assert {b._favorite_id for b in buttons} == {"f1"}
+
+    @pytest.mark.asyncio
+    async def test_async_favorites_attribute_excludes_internal_name(self):
+        from custom_components.roomba_plus.button_prime import (
+            async_favorites_attribute,
+        )
+
+        result = await async_favorites_attribute(_entry([
+            _favorite("f1", "Kitchen"),
+            _favorite("f2", "_mission_init_config_ABCDEF"),
+        ]))
+
+        assert result == [{"id": "f1", "name": "Kitchen"}]
+
+
 class TestTheSupersededPadDryButtons:
     """@chairstacker asked for the pad-dry button PAIR to be replaced by
     one switch. A switch was built beside them instead, so he ended up

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -167,6 +167,8 @@ def _make_callback_env():
     mission_store.async_append = AsyncMock()
     mission_store.async_save = AsyncMock()
     mission_store.consecutive_skips = 0
+    mission_store.update_terminal_fields = MagicMock(return_value=False)
+    mission_store.records = []
 
     runtime_data = MagicMock()
     runtime_data.mission_store = mission_store
@@ -662,6 +664,130 @@ class TestAsyncRecordMissionL3ErrorState:
             {"phase": "charge", "error": 18},
         )
         assert data.last_error_code == 18
+
+
+class TestAsyncRecordMissionReplayMerge:
+    """A same-mission-id replay (same start_ts, later wall-clock, a
+    different computed initiator/duration) must merge into the existing
+    terminal record in place rather than storing a second record."""
+
+    def _run_replay(self, first_mission, second_mission, first_now, second_now, start_ts):
+        from custom_components.roomba_plus.callbacks import async_record_mission
+        store = _make_store()
+        loop  = asyncio.new_event_loop()
+        entry = _make_entry(store)
+        hass  = _make_hass(loop)
+        try:
+            with patch(
+                "custom_components.roomba_plus.callbacks.dt_util.utcnow",
+                side_effect=[first_now, second_now],
+            ):
+                loop.run_until_complete(
+                    async_record_mission(hass, entry, first_mission, {}, [], start_ts, 0)
+                )
+                loop.run_until_complete(
+                    async_record_mission(hass, entry, second_mission, {}, [], start_ts, 0)
+                )
+        finally:
+            loop.close()
+        return store
+
+    def test_replay_freezes_first_write_and_stores_once(self):
+        now_real = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        start_ts  = now_real - 3 * 3600
+        first_now  = datetime.datetime.fromtimestamp(now_real - 2 * 3600, tz=datetime.timezone.utc)
+        # Replay pulse re-delivers the SAME terminal event within the
+        # MQTT re-delivery window (seconds, not hours).
+        second_now = first_now + datetime.timedelta(seconds=30)
+        first_mission  = {"phase": "charge", "error": 0, "sqft": 100, "initiator": "schedule"}
+        second_mission = {"phase": "charge", "error": 0, "sqft": 120, "initiator": "manual"}
+
+        store = self._run_replay(first_mission, second_mission, first_now, second_now, start_ts)
+
+        assert len(store.records) == 1
+        rec = store.records[0]
+        assert rec["duration_min"] == 60
+        assert rec["initiator"] == "schedule"
+        expected_started_at = datetime.datetime.fromtimestamp(
+            start_ts, tz=datetime.timezone.utc
+        ).isoformat()
+        assert rec["started_at"] == expected_started_at
+        assert rec["ended_at"] == first_now.isoformat()
+
+    def test_replay_two_hours_later_is_a_genuine_segment_not_a_merge(self):
+        """980/900-series multi-recharge keeps mssnStrtTm across segments: a
+        second write hours after the terminal record is the next segment
+        (async_append's _r<N> path), NOT an in-place replay merge."""
+        now_real = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        start_ts  = now_real - 3 * 3600
+        first_now  = datetime.datetime.fromtimestamp(now_real - 2 * 3600, tz=datetime.timezone.utc)
+        second_now = datetime.datetime.fromtimestamp(now_real, tz=datetime.timezone.utc)
+        first_mission  = {"phase": "charge", "error": 0, "sqft": 100, "initiator": "schedule"}
+        second_mission = {"phase": "charge", "error": 0, "sqft": 120, "initiator": "manual"}
+
+        store = self._run_replay(first_mission, second_mission, first_now, second_now, start_ts)
+
+        assert len(store.records) == 2
+        assert store.records[1]["id"].endswith("_r1"), store.records[1]["id"]
+
+    def test_replay_counted_once_by_missions_last_30d_query(self):
+        now_real = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        start_ts  = now_real - 3 * 3600
+        first_now  = datetime.datetime.fromtimestamp(now_real - 2 * 3600, tz=datetime.timezone.utc)
+        second_now = first_now + datetime.timedelta(seconds=30)
+        first_mission  = {"phase": "charge", "error": 0, "sqft": 100, "initiator": "schedule"}
+        second_mission = {"phase": "charge", "error": 0, "sqft": 120, "initiator": "manual"}
+
+        store = self._run_replay(first_mission, second_mission, first_now, second_now, start_ts)
+
+        assert len(store.query(30, result="completed")) == 1
+
+    def test_missions_last_30d_dedupes_legacy_recharge_segments(self):
+        from custom_components.roomba_plus.sensor_core import SENSORS
+
+        now_real = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        start_ts = now_real - 3 * 3600
+        first_now = datetime.datetime.fromtimestamp(
+            now_real - 2 * 3600, tz=datetime.timezone.utc
+        )
+        second_now = datetime.datetime.fromtimestamp(
+            now_real, tz=datetime.timezone.utc
+        )
+        store = self._run_replay(
+            {"phase": "charge", "error": 0, "sqft": 100, "initiator": "schedule"},
+            {"phase": "charge", "error": 0, "sqft": 120, "initiator": "manual"},
+            first_now,
+            second_now,
+            start_ts,
+        )
+        # Two segments of one physical mission (m_<start> + m_<start>_r1).
+        entity = MagicMock()
+        entity._config_entry.runtime_data.mission_store = store
+        descriptor = next(d for d in SENSORS if d.key == "missions_last_30d")
+
+        assert len(store.query(30, result="completed")) == 2
+        assert descriptor.value_fn(entity) == 1
+
+    def test_missions_last_30d_counts_idless_records_individually(self):
+        """Records without an id must never collapse into a single count via
+        the base-id dedupe (base_mission_id('') == '' for all of them)."""
+        from custom_components.roomba_plus.sensor_core import SENSORS
+
+        store = _make_store()
+        now_real = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        store._records = [
+            {"id": None, "started_at": _iso(now_real - 1000), "ended_at": _iso(now_real - 900), "result": "completed"},
+            {"id": "", "started_at": _iso(now_real - 800), "ended_at": _iso(now_real - 700), "result": "completed"},
+            {"id": 42, "started_at": _iso(now_real - 600), "ended_at": _iso(now_real - 500), "result": "completed"},
+            {"id": f"m_{now_real}", "started_at": _iso(now_real - 400), "ended_at": _iso(now_real - 300), "result": "completed"},
+            {"id": f"m_{now_real}_r1", "started_at": _iso(now_real - 200), "ended_at": _iso(now_real - 100), "result": "completed"},
+        ]
+        entity = MagicMock()
+        entity._config_entry.runtime_data.mission_store = store
+        descriptor = next(d for d in SENSORS if d.key == "missions_last_30d")
+
+        # 3 id-less (each counts once) + 1 deduped pair = 4 distinct missions.
+        assert descriptor.value_fn(entity) == 4
 
 
 class TestMakeMapRetrainCallback:
@@ -2385,6 +2511,95 @@ class TestFullLifecycleSequenceToResult:
             ("run", 0), ("pause", 0), ("run", 0),
         ])
         assert len(captured) == 0
+
+
+class TestPhaseTrackingReplayGuard:
+    """A phase flipping back to run/hmMidMsn/evac under an mssnStrtTm that
+    MissionStore already holds a terminal record for is a post-terminal
+    replay pulse, not a genuine new mission start."""
+
+    def test_replay_pulse_does_not_restart_timer_or_reopen_mission(self):
+        hass, entry, _recorded, mission_store = _make_callback_env()
+        mts = MagicMock()
+        mts.mission_id = None
+        entry.runtime_data.mission_timer_store = mts
+        cb = make_mission_callback(hass, entry)
+        captured: list[dict] = []
+
+        async def _capture(*args, **kwargs):
+            captured.append(dict(kwargs))
+
+        with patch("custom_components.roomba_plus.callbacks.async_record_mission",
+                   new_callable=AsyncMock) as mock_record, \
+             _patch_callbacks_time():
+            mock_record.side_effect = _capture
+            for phase, nstuck in [
+                ("run", 0), ("run", 0), ("charge", 0), ("charge", 0),
+            ]:
+                cb(_msg(phase, nstuck=nstuck))
+            hass.loop.run_until_complete(asyncio.sleep(0))
+            assert len(captured) == 1
+
+            mission_store.records = [{
+                "id": "m_1700000000",
+                "started_at": _iso(1700000000),
+                "result": "completed",
+            }]
+            mts.reset_mock()
+
+            for phase, nstuck in [("run", 0), ("charge", 0), ("charge", 0)]:
+                cb(_msg(phase, nstuck=nstuck))
+            hass.loop.run_until_complete(asyncio.sleep(0))
+
+        assert len(captured) == 1
+        mts.on_phase_run.assert_not_called()
+        mts.clear.assert_not_called()
+
+    def test_old_terminal_record_does_not_suppress_genuine_segment_resume(self):
+        """980/900-series keeps mssnStrtTm across multi-recharge segments: a
+        terminal record whose ended_at is far older than the re-delivery
+        window is a real segment resume, so the phase guard must not treat
+        it as a replay pulse."""
+        hass, entry, _recorded, mission_store = _make_callback_env()
+        mts = MagicMock()
+        mts.mission_id = None
+        entry.runtime_data.mission_timer_store = mts
+        cb = make_mission_callback(hass, entry)
+        captured: list[dict] = []
+
+        async def _capture(*args, **kwargs):
+            captured.append(dict(kwargs))
+
+        from custom_components.roomba_plus.callbacks import _CLOUD_CATCHUP_MISSION_MATCH_SEC
+
+        with patch("custom_components.roomba_plus.callbacks.async_record_mission",
+                   new_callable=AsyncMock) as mock_record,              _patch_callbacks_time():
+            mock_record.side_effect = _capture
+            for phase, nstuck in [
+                ("run", 0), ("run", 0), ("charge", 0), ("charge", 0),
+            ]:
+                cb(_msg(phase, nstuck=nstuck))
+            hass.loop.run_until_complete(asyncio.sleep(0))
+            assert len(captured) == 1
+
+            # Terminal record from LONG ago (started_at == ended_at, old timestamp).
+            old_ts = 1700000000  # 2.7 years before the live clock — well outside window
+            mission_store.records = [{
+                "id": "m_1700000000",
+                "started_at": _iso(old_ts),
+                "ended_at": _iso(old_ts),
+                "result": "completed",
+            }]
+            mts.reset_mock()
+
+            for phase, nstuck in [("run", 0), ("charge", 0), ("charge", 0)]:
+                cb(_msg(phase, nstuck=nstuck))
+            hass.loop.run_until_complete(asyncio.sleep(0))
+
+        # Genuine resume: a second mission record gets recorded and the timer
+        # tracks the resumed segment.
+        assert len(captured) == 2
+        mts.on_phase_run.assert_called_once()
 
 
 class TestCloudRefreshCallbackDispatchesV320Checks:

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -80,6 +80,60 @@ class TestLocationNameNullRegression:
         assert tracker.state == "Docked"
 
 
+class TestLocaleLabelsCoverAllShippedTranslations:
+    """de/en were the only tables filled in; the other six shipped
+    locales (es/fr/it/nl/pl/pt) silently fell back to English state
+    text regardless of the user's Home Assistant language."""
+
+    def test_docked_label_in_polish(self):
+        tracker, roomba, _ = _make_tracker()
+        tracker.hass.config.language = "pl"
+        _set_state(roomba, phase="charge")
+        assert tracker.state == "Zadokowany"
+
+    def test_stuck_label_in_polish(self):
+        tracker, roomba, _ = _make_tracker()
+        tracker.hass.config.language = "pl"
+        _set_state(roomba, phase="stuck")
+        assert tracker.state == "Utknął"
+
+    def test_error_label_in_polish(self):
+        tracker, roomba, _ = _make_tracker()
+        tracker.hass.config.language = "pl"
+        _set_state(roomba, phase="stop", error=1010)
+        assert tracker.state == "Błąd"
+
+    def test_active_fallback_label_in_polish(self):
+        tracker, roomba, _ = _make_tracker(map_capability_value="ephemeral")
+        tracker.hass.config.language = "pl"
+        _set_state(roomba, phase="run")
+        assert tracker.state == "Sprzątanie"
+
+    def test_docked_label_in_spanish(self):
+        tracker, roomba, _ = _make_tracker()
+        tracker.hass.config.language = "es"
+        _set_state(roomba, phase="charge")
+        assert tracker.state == "Acoplado"
+
+    def test_stuck_label_in_spanish(self):
+        tracker, roomba, _ = _make_tracker()
+        tracker.hass.config.language = "es"
+        _set_state(roomba, phase="stuck")
+        assert tracker.state == "Atascado"
+
+    def test_error_label_in_spanish(self):
+        tracker, roomba, _ = _make_tracker()
+        tracker.hass.config.language = "es"
+        _set_state(roomba, phase="stop", error=1010)
+        assert tracker.state == "Error"
+
+    def test_active_fallback_label_in_spanish(self):
+        tracker, roomba, _ = _make_tracker(map_capability_value="ephemeral")
+        tracker.hass.config.language = "es"
+        _set_state(roomba, phase="run")
+        assert tracker.state == "Limpiando"
+
+
 class TestLocationNameSmartTier:
     """SMART-tier robots get room-level granularity, shared with
     RoombaMissionProgress's current_room via _resolve_smart_tier_room_state."""

--- a/tests/test_grid_store.py
+++ b/tests/test_grid_store.py
@@ -1001,6 +1001,68 @@ class TestGridStoreEdgeRatioCache:
         assert 300.0 in gs._edge_ratio_cache
 
 
+class TestEdgeCoverageRatioRetainedAcrossSparseMissions:
+    def test_sparse_update_retains_prior_valid_ratio(self):
+        gs = _make_grid_with_cells(100)
+        valid = gs.edge_coverage_ratio()
+        assert valid is not None
+
+        gs.update_from_mission([(0.0, 0.0)], [])
+        gs._cells = {(0, 0): 0.5}
+
+        assert gs.edge_coverage_ratio() == valid
+
+    def test_non_default_depth_does_not_use_retained_ratio(self):
+        gs = _make_grid_with_cells(300)
+        gs.edge_coverage_ratio()
+        gs._cells = {(0, 0): 0.5}
+
+        assert gs.edge_coverage_ratio(edge_depth_mm=500.0) is None
+
+    def test_fresh_valid_ratio_overwrites_retained_value(self):
+        gs = _make_grid_with_cells(100)
+        first = gs.edge_coverage_ratio()
+        gs.update_from_mission([(0.0, 0.0)], [])
+        gs._cells = {
+            (i, i): 0.5 for i in range(30)
+        }
+        second = gs.edge_coverage_ratio()
+        assert second is not None
+        assert second != first
+        gs._cells = {(0, 0): 0.5}
+        assert gs.edge_coverage_ratio() == second
+
+    @pytest.mark.asyncio
+    async def test_retained_ratio_survives_save_load_roundtrip(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        gs = _make_grid_with_cells(100)
+        valid = gs.edge_coverage_ratio()
+        gs._cells = {(0, 0): 0.5}
+        assert gs.edge_coverage_ratio() == valid
+
+        saved_data: dict = {}
+        hass = MagicMock()
+        store_mock = AsyncMock()
+
+        async def _capture_save(data):
+            saved_data.update(data)
+
+        store_mock.async_save = _capture_save
+        with patch("homeassistant.helpers.storage.Store", return_value=store_mock):
+            await gs.async_save(hass, "test_entry")
+        assert saved_data["last_valid_edge_coverage_ratio"] == valid
+
+        gs2 = GridStore()
+        store_mock.async_load = AsyncMock(return_value=saved_data)
+        with patch("homeassistant.helpers.storage.Store", return_value=store_mock):
+            await gs2.async_load(hass, "test_entry")
+
+        assert gs2._cells == {(0, 0): pytest.approx(0.5)}
+        assert gs2.edge_coverage_ratio() == valid
+
+
+
 class TestGridStoreL7Format:
     """_stuck dict uses new structured format."""
 

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -1,0 +1,133 @@
+"""Icons registry coverage guard (live investigation #4).
+
+icons.json must carry an entry for every entity the integration creates.
+HA matches icons by platform + entity translation_key, so this scans each
+platform module's descriptors/classes for translation keys and asserts a
+registry entry exists — with an allowlist for entities that deliberately
+set their own icon (explicit _attr_icon) or have no translation key.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent / "custom_components" / "roomba_plus"
+_ICONS = _ROOT / "icons.json"
+
+
+def _load_icons() -> dict:
+    return json.loads(_ICONS.read_text())["entity"]
+
+
+def _translation_keys_in_source(module_name: str) -> set[str]:
+    """All translation_key literals used for entity descriptions/classes
+    in a platform module: keyword-arg form, _attr_translation_key class
+    attributes, and translation_key= arguments inside dynamic
+    entity_description assignments."""
+    keys: set[str] = set()
+    tree = ast.parse((_ROOT / module_name).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "translation_key" and isinstance(kw.value, ast.Constant):
+                    keys.add(kw.value.value)
+        elif isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                target_is_key = (
+                    (isinstance(tgt, ast.Attribute) and tgt.attr == "_attr_translation_key")
+                    or (isinstance(tgt, ast.Name) and tgt.id == "_attr_translation_key")
+                )
+                if target_is_key and isinstance(node.value, ast.Constant):
+                    keys.add(node.value.value)
+    return {k for k in keys if isinstance(k, str)}
+
+
+# Keys set programmatically (dynamic command keys, translation
+# placeholders), not as translation_key literals in source.
+# Entities that set their own _attr_icon (HA precedence over the registry)
+# — a registry entry would be dead weight.
+_EXPLICIT_ICON_KEYS = frozenset({
+    "prime_quiet_hours", "prime_quiet_hours_active",
+    "prime_cleaning_mode", "prime_map",
+})
+
+
+_DYNAMIC_ICON_KEYS = frozenset({
+    "prime_empty_bin", "prime_wash_pad", "prime_stop_pad_dry",
+    "prime_start_pad_dry", "favorite",
+})
+
+
+_LEGACY_ICON_KEYS = frozenset({
+    # Deprecated CloudRaw sensors deactivated in SC1 (v3.0); entries kept
+    # for already-registered entities' display continuity.
+    "recent_completion_rate", "recent_cleaning_speed", "recent_coverage_pct",
+    "cleaning_speed_trend", "recent_dirt_density", "recent_recharge_fraction",
+    "recent_recharges", "recent_evacuations", "recent_dirt_events",
+    "recent_error_code", "recent_error_time",
+    "recent_wifi_floor", "recent_wifi_stability",
+})
+
+
+@pytest.mark.parametrize(
+    ("module", "domain"),
+    [
+        ("sensor_core.py", "sensor"),
+        ("sensor_cloud.py", "sensor"),
+        ("sensor_rooms.py", "sensor"),
+        ("sensor_diagnostics.py", "sensor"),
+        ("sensor_prime.py", "sensor"),
+        ("binary_sensor.py", "binary_sensor"),
+        ("button.py", "button"),
+        ("button_prime.py", "button"),
+        ("select.py", "select"),
+        ("select_prime.py", "select"),
+        ("switch.py", "switch"),
+        ("prime_schedule_switch.py", "switch"),
+        ("image.py", "image"),
+        ("device_tracker.py", "device_tracker"),
+        ("calendar.py", "calendar"),
+        ("todo.py", "todo"),
+        ("todo_prime.py", "todo"),
+    ],
+)
+def test_platform_translation_keys_have_icons(module: str, domain: str) -> None:
+    icons = _load_icons()
+    registry = icons.get(domain, {})
+    used = _translation_keys_in_source(module)
+    missing = sorted(k for k in used if k not in registry and k not in _EXPLICIT_ICON_KEYS)
+    assert not missing, (
+        f"{domain} icons.json missing entries for {missing} "
+        f"(translation keys used in {module})"
+    )
+
+
+def test_icons_entries_refer_to_real_keys() -> None:
+    """Every registry key must be findable as an entity translation_key
+    somewhere in the source (stale registry entries are drift)."""
+    icons = _load_icons()
+    for domain, entries in icons.items():
+        used: set[str] = set()
+        modules = {
+            "sensor": ("sensor_core.py", "sensor_cloud.py", "sensor_rooms.py",
+                       "sensor_diagnostics.py", "sensor_prime.py"),
+            "binary_sensor": ("binary_sensor.py",),
+            "button": ("button.py", "button_prime.py"),
+            "select": ("select.py", "select_prime.py"),
+            "switch": ("switch.py", "prime_schedule_switch.py"),
+            "image": ("image.py",),
+            "device_tracker": ("device_tracker.py",),
+            "calendar": ("calendar.py",),
+            "todo": ("todo.py", "todo_prime.py"),
+        }.get(domain, ())
+        for m in modules:
+            used |= _translation_keys_in_source(m)
+        unknown = sorted(set(entries) - used - _LEGACY_ICON_KEYS - _DYNAMIC_ICON_KEYS)
+        assert not unknown, (
+            f"icons.json {domain} entries {unknown} have no matching "
+            "translation_key in the platform source — remove or allowlist"
+        )

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -638,6 +638,229 @@ class TestCoverageMapSignal:
         assert asyncio.iscoroutinefunction(_async_send_coverage_signal)
 
 
+class TestTerminalMissionImageRefresh:
+    @pytest.mark.asyncio
+    async def test_empty_terminal_refreshes_all_images_once(self):
+        from custom_components.roomba_plus.grid_store import GridStore
+        from custom_components.roomba_plus.image import (
+            RoombaCoverageImage,
+            RoombaMapImage,
+            RoombaRoomsImage,
+            _SIGNAL_COVERAGE_UPDATED,
+        )
+        from homeassistant.util import dt as dt_util
+
+        entry = MagicMock()
+        entry.entry_id = "test_entry"
+        entry.runtime_data = MagicMock()
+        entry.runtime_data.grid_store = GridStore()
+        entry.runtime_data.umf_aligner = None
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        before = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+        listeners: dict[str, list[Any]] = {}
+
+        def connect(_hass, signal, listener):
+            listeners.setdefault(signal, []).append(listener)
+            return lambda: None
+
+        coverage = RoombaCoverageImage.__new__(RoombaCoverageImage)
+        coverage._config_entry = entry
+        coverage._grid_store = entry.runtime_data.grid_store
+        coverage._cache = b"old"
+        coverage._attr_image_last_updated = before
+        coverage.hass = hass
+        coverage.async_update_token = MagicMock()
+        coverage.async_on_remove = MagicMock()
+        coverage.async_write_ha_state = MagicMock()
+
+        rooms = RoombaRoomsImage.__new__(RoombaRoomsImage)
+        rooms._config_entry = entry
+        rooms._cache = b"old"
+        rooms._attr_image_last_updated = before
+        rooms.hass = hass
+        rooms.async_update_token = MagicMock()
+        rooms.async_on_remove = MagicMock()
+        rooms.async_write_ha_state = MagicMock()
+
+        with (
+            patch.object(IRobotEntity, "async_added_to_hass", new=AsyncMock()),
+            patch(
+                "homeassistant.helpers.dispatcher.async_dispatcher_connect",
+                side_effect=connect,
+            ),
+        ):
+            await coverage.async_added_to_hass()
+            await rooms.async_added_to_hass()
+
+        route = RoombaMapImage.__new__(RoombaMapImage)
+        route.hass = hass
+        route._config_entry = entry
+        route._mission_points = []
+        route._mission_thetas = []
+        route._stuck_mission_points = []
+        route._mission_start_ts = "2026-09-02T10:00:00+00:00"
+        route._mission_checkpoint_mssn_strt_tm = 987654
+        route._last_terminal_mission_key = None
+        route.vacuum_state = {
+            "cleanMissionStatus": {"mssnStrtTm": 987654},
+        }
+        route._cache = b"old"
+        route._attr_image_last_updated = before
+
+        scheduled = []
+
+        def schedule(coro, _loop):
+            scheduled.append(coro)
+            return MagicMock()
+
+        with patch(
+            "custom_components.roomba_plus.image.asyncio.run_coroutine_threadsafe",
+            side_effect=schedule,
+        ):
+            route._handle_mission_end()
+            route._handle_mission_end()
+
+        refresh_coroutines = [
+            coro
+            for coro in scheduled
+            if coro.cr_code.co_name == "_async_send_coverage_signal"
+        ]
+        assert len(refresh_coroutines) == 1
+        signal = _SIGNAL_COVERAGE_UPDATED.format(entry.entry_id)
+
+        def send(_hass, dispatched_signal):
+            for listener in listeners[dispatched_signal]:
+                listener()
+
+        with patch(
+            "homeassistant.helpers.dispatcher.async_dispatcher_send",
+            side_effect=send,
+        ):
+            await refresh_coroutines[0]
+
+        for coro in scheduled:
+            if coro not in refresh_coroutines:
+                coro.close()
+
+        assert route._attr_image_last_updated > before
+        assert route._cache is None
+        assert coverage._attr_image_last_updated > before
+        assert coverage._cache is None
+        coverage.async_write_ha_state.assert_called_once()
+        assert rooms._attr_image_last_updated > before
+        assert rooms._cache is None
+        rooms.async_write_ha_state.assert_called_once()
+        assert len(listeners[signal]) == 2
+
+    @pytest.mark.asyncio
+    async def test_pose_present_terminal_still_feeds_grid_and_refreshes_images(self):
+        """A mission WITH pose data must both feed GridStore (unchanged
+        live path) and fire the same terminal image-refresh signal — the
+        refresh call moved earlier in _handle_mission_end but nothing
+        after it changed."""
+        from custom_components.roomba_plus.grid_store import GridStore
+        from custom_components.roomba_plus.image import (
+            RoombaCoverageImage,
+            RoombaMapImage,
+            _SIGNAL_COVERAGE_UPDATED,
+        )
+
+        entry = MagicMock()
+        entry.entry_id = "test_entry"
+        entry.runtime_data = MagicMock()
+        gs = GridStore()
+        entry.runtime_data.grid_store = gs
+        entry.runtime_data.umf_aligner = None
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        before = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+        listeners: dict[str, list[Any]] = {}
+
+        def connect(_hass, signal, listener):
+            listeners.setdefault(signal, []).append(listener)
+            return lambda: None
+
+        coverage = RoombaCoverageImage.__new__(RoombaCoverageImage)
+        coverage._config_entry = entry
+        coverage._grid_store = gs
+        coverage._cache = b"old"
+        coverage._attr_image_last_updated = before
+        coverage.hass = hass
+        coverage.async_update_token = MagicMock()
+        coverage.async_on_remove = MagicMock()
+        coverage.async_write_ha_state = MagicMock()
+
+        with (
+            patch.object(IRobotEntity, "async_added_to_hass", new=AsyncMock()),
+            patch(
+                "homeassistant.helpers.dispatcher.async_dispatcher_connect",
+                side_effect=connect,
+            ),
+        ):
+            await coverage.async_added_to_hass()
+
+        route = RoombaMapImage.__new__(RoombaMapImage)
+        route.hass = hass
+        route._config_entry = entry
+        route._renderer = MagicMock()
+        route._renderer._cfg.robot_diameter_mm = 300
+        route._zone_store = None
+        route._map_capability = None
+        route._mission_points = [(0.0, 0.0), (100.0, 100.0)]
+        route._mission_thetas = [0.0, 0.0]
+        route._stuck_mission_points = []
+        route._mission_start_ts = "2026-09-02T10:00:00+00:00"
+        route._mission_checkpoint_mssn_strt_tm = 987654
+        route._last_terminal_mission_key = None
+        route.vacuum_state = {
+            "cleanMissionStatus": {"mssnStrtTm": 987654},
+            "bbmssn": {"nMssn": 77},
+        }
+        route._cache = b"old"
+        route._attr_image_last_updated = before
+
+        scheduled = []
+
+        def schedule(coro, _loop):
+            scheduled.append(coro)
+            return MagicMock()
+
+        with patch(
+            "custom_components.roomba_plus.image.asyncio.run_coroutine_threadsafe",
+            side_effect=schedule,
+        ):
+            route._handle_mission_end()
+
+        assert gs.last_processed_nmssn == 77
+
+        refresh_coroutines = [
+            coro for coro in scheduled
+            if coro.cr_code.co_name == "_async_send_coverage_signal"
+        ]
+        assert len(refresh_coroutines) == 1
+        signal = _SIGNAL_COVERAGE_UPDATED.format(entry.entry_id)
+
+        def send(_hass, dispatched_signal):
+            for listener in listeners[dispatched_signal]:
+                listener()
+
+        with patch(
+            "homeassistant.helpers.dispatcher.async_dispatcher_send",
+            side_effect=send,
+        ):
+            await refresh_coroutines[0]
+
+        for coro in scheduled:
+            if coro not in refresh_coroutines:
+                coro.close()
+
+        assert route._attr_image_last_updated > before
+        assert coverage._attr_image_last_updated > before
+        assert coverage._cache is None
+        coverage.async_write_ha_state.assert_called_once()
+
+
 class TestXvmcCoords:
     """rooms.outline and x/y must be in vacuum mm, not image pixels."""
 

--- a/tests/test_mission_store.py
+++ b/tests/test_mission_store.py
@@ -638,6 +638,150 @@ class TestAsyncAppend:
         # After trim, latest should be the last-appended
         assert store.latest()["id"] == f"m_{MAX_RECORDS + 4}"
 
+    @pytest.mark.asyncio
+    async def test_update_terminal_fields_merges_additive_fields_in_place(self):
+        store = MissionStore()
+        existing = _make_record(result="completed", area_sqft=None, zones=[])
+        existing["id"] = "m_1700000000"
+        existing["npicks_delta"] = 0
+        existing["ended_at"] = "2099-01-01T01:59:00+00:00"
+        await store.async_append(existing)
+
+        incoming = {
+            "id": "m_1700000000",
+            "started_at": "2099-01-01T00:00:00+00:00",
+            "ended_at": "2099-01-01T02:00:00+00:00",
+            "duration_min": 999,
+            "initiator": "manual",
+            "result": "cancelled",
+            "area_sqft": 250.0,
+            "zones": ["Kitchen"],
+            "error_code": 17,
+            "npicks_delta": 3,
+        }
+        merged = store.update_terminal_fields("m_1700000000", incoming)
+
+        assert merged is True
+        rec = store.latest()
+        assert rec["area_sqft"] == 250.0
+        assert rec["zones"] == ["Kitchen"]
+        assert rec["npicks_delta"] == 3
+        assert rec["error_code"] == 17
+        assert rec["duration_min"] == existing["duration_min"]
+        assert rec["initiator"] == "schedule"
+        assert rec["result"] == "completed"
+        assert rec["started_at"] == existing["started_at"]
+        assert rec["ended_at"] == existing["ended_at"]
+        assert rec["id"] == "m_1700000000"
+
+    @pytest.mark.asyncio
+    async def test_update_terminal_fields_returns_false_when_no_match(self):
+        store = MissionStore()
+        await store.async_append(_make_record(result="completed"))
+        merged = store.update_terminal_fields(
+            "m_does_not_exist", {"id": "m_does_not_exist"}
+        )
+        assert merged is False
+
+    @pytest.mark.asyncio
+    async def test_update_terminal_fields_returns_false_for_non_terminal_result(self):
+        store = MissionStore()
+        placeholder = _make_record(result=None)
+        placeholder["id"] = "m_1700000000"
+        await store.async_append(placeholder)
+        merged = store.update_terminal_fields(
+            "m_1700000000", {"id": "m_1700000000", "area_sqft": 10}
+        )
+        assert merged is False
+        assert store.latest()["area_sqft"] != 10
+        assert MissionStore.is_terminal_result("unknown") is True
+        assert MissionStore.is_terminal_result("in_progress") is False
+
+    @pytest.mark.asyncio
+    async def test_update_terminal_fields_matches_across_recharge_segment_suffix(self):
+        store = MissionStore()
+        segment = _make_record(result="completed", area_sqft=None)
+        segment["id"] = "m_1700000000_r1"
+        await store.async_append(segment)
+        merge_rec = _make_record(result="completed")
+        merge_rec["ended_at"] = segment["ended_at"]
+        merge_rec["area_sqft"] = 42
+        merge_rec["zones"] = []
+        merged = store.update_terminal_fields("m_1700000000", merge_rec)
+        assert merged is True
+        assert store.latest()["area_sqft"] == 42
+
+    @pytest.mark.asyncio
+    async def test_update_terminal_fields_does_not_overwrite_existing_area_sqft(self):
+        store = MissionStore()
+        existing = _make_record(result="completed", area_sqft=100.0)
+        existing["id"] = "m_1700000000"
+        await store.async_append(existing)
+        store.update_terminal_fields(
+            "m_1700000000",
+            {"id": "m_1700000000", "area_sqft": 999,
+             "ended_at": existing["ended_at"]},
+        )
+        assert store.latest()["area_sqft"] == 100.0
+
+    @pytest.mark.asyncio
+    async def test_update_terminal_fields_falls_through_for_later_recharge_segment(self):
+        """A terminal record far older than the replay window is a genuine
+        980/900-series recharge-segment resume: update_terminal_fields must
+        NOT merge in place, so async_append's _r<N> segment path stays
+        reachable and segment 2 keeps its own duration/area."""
+        store = MissionStore()
+        existing = _make_record(result="completed", area_sqft=100.0)
+        existing["id"] = "m_1700000000"
+        await store.async_append(existing)
+
+        later = _make_record(result="completed")
+        later["id"] = "m_1700000000"
+        later["ended_at"] = "2099-01-01T02:00:00+00:00"  # hours later than existing
+        later["area_sqft"] = 250.0
+        merged = store.update_terminal_fields("m_1700000000", later)
+
+        assert merged is False
+
+    @pytest.mark.asyncio
+    async def test_update_terminal_fields_replay_within_window_merges(self):
+        """A terminal re-delivery arriving within the replay window merges in
+        place (additive fields only) — no new segment record is created."""
+        store = MissionStore()
+        existing = _make_record(result="completed", area_sqft=None)
+        existing["id"] = "m_1700000000"
+        await store.async_append(existing)
+
+        replay = _make_record(result="completed")
+        replay["id"] = "m_1700000000"
+        replay["ended_at"] = existing["ended_at"]  # re-delivery of same terminal event
+        replay["area_sqft"] = 42.0
+        merged = store.update_terminal_fields("m_1700000000", replay)
+
+        assert merged is True
+        assert len(store.query(365)) == 1
+        assert store.latest()["area_sqft"] == 42.0
+
+    @pytest.mark.asyncio
+    async def test_update_terminal_fields_keeps_larger_npicks_delta(self):
+        store = MissionStore()
+        existing = _make_record(result="completed")
+        existing["id"] = "m_1700000000"
+        existing["npicks_delta"] = 1
+        await store.async_append(existing)
+        store.update_terminal_fields(
+            "m_1700000000",
+            {"id": "m_1700000000", "npicks_delta": 4,
+             "ended_at": existing["ended_at"]},
+        )
+        assert store.latest()["npicks_delta"] == 4
+        store.update_terminal_fields(
+            "m_1700000000",
+            {"id": "m_1700000000", "npicks_delta": 2,
+             "ended_at": existing["ended_at"]},
+        )
+        assert store.latest()["npicks_delta"] == 4
+
 
 class TestQuery:
     @pytest.mark.asyncio
@@ -1651,6 +1795,55 @@ class TestL6Helpers:
 
         assert _presence_utilisation(_FakeEntity(), 7) is None
 
+    @pytest.mark.asyncio
+    async def test_presence_utilisation_used_matches_opportunities_population(self):
+        """`used` must apply the same duration_min >= avg_duration filter as
+        `opportunities`, otherwise a short away-window that still resulted in
+        a clean inflates the numerator without inflating the denominator and
+        the percentage can exceed 100.
+        """
+        from custom_components.roomba_plus.sensor import _presence_utilisation
+
+        store = MissionStore()
+        now = datetime.datetime.now(datetime.timezone.utc)
+        start = now - datetime.timedelta(hours=6)
+        gaps_min = [10, 10, 10, 50]  # three short, one >= the 45-min avg_duration
+        t = start
+        for i, gap in enumerate(gaps_min):
+            ended = t + datetime.timedelta(minutes=45)
+            await store.async_append({
+                "id": f"m_{i}",
+                "started_at": t.isoformat(),
+                "ended_at": ended.isoformat(),
+                "duration_min": 45,
+                "area_sqft": 400.0,
+                "result": "completed",
+                "initiator": "schedule",
+                "zones": [],
+                "error_code": None,
+                "bbrun_hr": 100,
+            })
+            t = ended + datetime.timedelta(minutes=gap)
+        await store.async_append({
+            "id": "m_last",
+            "started_at": t.isoformat(),
+            "ended_at": (t + datetime.timedelta(minutes=45)).isoformat(),
+            "duration_min": 45,
+            "area_sqft": 400.0,
+            "result": "completed",
+            "initiator": "schedule",
+            "zones": [],
+            "error_code": None,
+            "bbrun_hr": 100,
+        })
+
+        entity = self._make_entity_with_store(store)
+        result = _presence_utilisation(entity, 7)
+
+        assert result is not None
+        assert result <= 100.0
+        assert result == 100.0
+
 
 class TestMssnStrtTmCaching:
     """Verify the closure caches start_ts at mission start, not end."""
@@ -1916,8 +2109,13 @@ class TestErrorRestoreLogic:
         last_error_zone = None
         for _rec in reversed(records):
             _res = _rec.get("result")
-            if _res in ("error", "stuck") and _rec.get("error_code"):
+            if _res in MissionStore.ERROR_RESULTS and _rec.get("error_code"):
                 last_error_code = _rec["error_code"]
+                last_error_at   = _rec.get("ended_at")
+                last_error_zone = (_rec.get("zones") or [None])[0]
+                break
+            elif _res in MissionStore.STUCK_RESULTS:
+                last_error_code = None
                 last_error_at   = _rec.get("ended_at")
                 last_error_zone = (_rec.get("zones") or [None])[0]
                 break
@@ -1996,6 +2194,26 @@ class TestErrorRestoreLogic:
         ]
         code, _, _ = self._restore_error(records)
         assert code == 15
+
+    def test_stuck_without_error_code_restores_triplet(self):
+        """Code-less stuck: at/zone still restored, code stays None (not skipped)."""
+        records = [
+            {**_make_record_v192_fixes(1, result="stuck", error_code=None), "zones": ["Kitchen"]},
+        ]
+        code, at, zone = self._restore_error(records)
+        assert code is None
+        assert at is not None
+        assert zone == "Kitchen"
+
+    def test_stuck_without_error_code_not_shadowed_by_older_coded_error(self):
+        """Most-recent code-less stuck wins over an older coded error."""
+        records = [
+            _make_record_v192_fixes(2, result="error", error_code=17),
+            {**_make_record_v192_fixes(1, result="stuck_and_abandoned", error_code=None), "zones": ["Hallway"]},
+        ]
+        code, at, zone = self._restore_error(records)
+        assert code is None
+        assert zone == "Hallway"
 
 
 class TestLastMissionFromStore:
@@ -2161,6 +2379,46 @@ class TestBackfillBasicCorrection:
         )
 
 
+    def test_same_terminal_record_cannot_be_result_corrected_twice(self):
+        """Cloud truth applies once: after B1-EXT corrects 'completed' to
+        'error' (done==bat), a later merge with a contradictory cloud record
+        must not flip the same record again (no error<->cancelled
+        oscillation). Timing/identity fields stay frozen throughout."""
+        store = MissionStore()
+        local = _local_rec(started_ts=1700000000, ended_ts=1700003600)
+        local["result"] = "completed"
+        store = _make_store([local])
+
+        store.backfill_from_cloud([{**_cloud_rec(1700000000, 1700003600),
+                                     "done": "bat", "done_raw": "bat"}])
+        assert store._records[0]["result"] == "error"
+
+        # A later, contradictory cloud record for the same end-time.
+        store.backfill_from_cloud([{
+            "startTime": 1700000000, "timestamp": 1700003600,
+            "done": "cncl", "done_raw": "usrEnd", "pauseId": 5,
+        }])
+        assert store._records[0]["result"] == "error", (
+            "once cloud-corrected, a terminal result is immutable"
+        )
+
+    def test_terminal_result_rewrite_is_exempt_only_for_first_cloud_truth(self):
+        """merge_latest_from_cloud applies the same once-only rule."""
+        store = MissionStore()
+        local = _local_rec(started_ts=1700000000, ended_ts=1700003600)
+        local["result"] = "completed"
+        store = _make_store([local])
+
+        store.merge_latest_from_cloud([{**_cloud_rec(1700000000, 1700003600),
+                                           "done": "bat", "done_raw": "bat"}])
+        assert store._records[0]["result"] == "error"
+        store.merge_latest_from_cloud([{
+            "startTime": 1700000000, "timestamp": 1700003600,
+            "done": "cncl", "done_raw": "usrEnd", "pauseId": 5,
+        }])
+        assert store._records[0]["result"] == "error"
+
+
 class TestBackfillMatching:
 
     def test_matches_within_tolerance(self):
@@ -2223,9 +2481,7 @@ class TestBackfillMatching:
         ]
         n = store.backfill_from_cloud(cloud)
         assert n.corrected == 1
-        # local1 unchanged
         assert store._records[0]["started_at"] == _utc(start_accurate)
-        # local2 corrected
         assert store._records[1]["started_at"] == _utc(1700003700)
 
 

--- a/tests/test_presence_manager.py
+++ b/tests/test_presence_manager.py
@@ -643,6 +643,7 @@ class TestTotalEnergyConsumed:
         entity = MagicMock()
         entity.battery_stats = {"estCap": 2500, "nLithChrg": 100}
         entity._config_entry.runtime_data.robot_profile = None
+        entity._config_entry.runtime_data.robot_profile_store = RobotProfileStore()
         # 2500 mAh × 14.8 V × 100 cycles = 3.7 kWh
         result = desc.value_fn(entity)
         assert result is not None
@@ -660,6 +661,7 @@ class TestTotalEnergyConsumed:
             "nNimhChrg": 0,
         }
         entity._config_entry.runtime_data.robot_profile = ROBOT_PROFILES["9"]
+        entity._config_entry.runtime_data.robot_profile_store = RobotProfileStore()
         result = _total_energy_consumed_kwh(entity)
         assert result is not None
         # 3300 mAh × 14.4V × 1 cycle / 1_000_000 ≈ 0.0475 kWh
@@ -677,6 +679,7 @@ class TestTotalEnergyConsumed:
             "nNimhChrg": 1,
         }
         entity._config_entry.runtime_data.robot_profile = ROBOT_PROFILES["9"]
+        entity._config_entry.runtime_data.robot_profile_store = RobotProfileStore()
         result = _total_energy_consumed_kwh(entity)
         assert result is not None
         # 3300 mAh × 14.4V × 1 cycle / 1_000_000
@@ -701,11 +704,26 @@ class TestTotalEnergyConsumed:
             "nNimhChrg": 1,       # first NiMH cycle
         }
         entity._config_entry.runtime_data.robot_profile = ROBOT_PROFILES["9"]
+        entity._config_entry.runtime_data.robot_profile_store = RobotProfileStore()
         result = _total_energy_consumed_kwh(entity)
         assert result is not None
         # Must use NiMH scale (÷ 1.87), not Li-ion (÷ 3.73)
         # 3300 mAh × 14.4V × 1 cycle / 1_000_000
         assert abs(result - round(3300 * 14.4 * 1 / 1_000_000, 3)) < 0.005
+
+    def test_energy_never_decreases_below_high_water_mark(self):
+        from custom_components.roomba_plus.sensor import _total_energy_consumed_kwh
+        entity = MagicMock()
+        entity.battery_stats = {"estCap": 2500, "nLithChrg": 10}
+        entity._config_entry.runtime_data.robot_profile = None
+        store = RobotProfileStore()
+        store.lifetime_energy_kwh_high_water = 5.0
+        entity._config_entry.runtime_data.robot_profile_store = store
+        # 2500 mAh × 14.8 V × 10 cycles / 1_000_000 = 0.37 kWh, below the
+        # stored high-water mark.
+        result = _total_energy_consumed_kwh(entity)
+        assert result == 5.0
+        assert store.lifetime_energy_kwh_high_water == 5.0
 
     def test_returns_none_when_no_cycles(self):
         from custom_components.roomba_plus.sensor import SENSORS
@@ -750,8 +768,11 @@ class TestRecordCleanEventWiring:
         import inspect
         from custom_components.roomba_plus import callbacks
         src = inspect.getsource(callbacks)
-        # v2.6.3: _CLEANING_PHASES guard replaced by had_cleaning_phase flag
-        phase_idx = src.find('_ACTIVE_CLEANING_PHASES and not had_cleaning_phase')
+        # v2.6.3: _CLEANING_PHASES guard replaced by had_cleaning_phase flag;
+        # v4.0.0b3 live-investigation fix: the guard additionally rejects
+        # post-terminal replay pulses (_mission_already_terminal), so the
+        # exact-string match anchors on the phase list membership check.
+        phase_idx = src.find('phase in _ACTIVE_CLEANING_PHASES')
         record_idx = src.find('record_clean_event')
         assert phase_idx != -1, "_ACTIVE_CLEANING_PHASES mission-start guard not found in callbacks.py"
         assert record_idx != -1, "record_clean_event not found in callbacks.py"
@@ -761,10 +782,12 @@ class TestRecordCleanEventWiring:
         )
         # v2.9.0 — threshold bumped 800→900: F4e's current_leg_rechrgM
         # double-counting bugfix added one legitimate reset line to this
-        # exact span (mission-start block). record_clean_event's actual
-        # placement (still immediately after the phase-guard block) is
-        # unchanged — this is proximity slack, not a placement regression.
-        assert record_idx - phase_idx < 900, (
+        # exact span (mission-start block); the v4.0.0b3 live-fix added the
+        # _mission_already_terminal replay-guard condition to the same guard
+        # (1100 now). record_clean_event's actual placement (still
+        # immediately after the phase-guard block) is unchanged — this is
+        # proximity slack, not a placement regression.
+        assert record_idx - phase_idx < 1100, (
             "record_clean_event is too far from the mission-start transition — check placement"
         )
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1237,6 +1237,41 @@ class TestSelectSetupEntryRouting:
         mqtt_selects = [e for e in created if isinstance(e, SmartZoneSelect)]
         assert len(cloud_selects) == 0
         assert len(mqtt_selects) == 1, f"Expected 1 SmartZoneSelect, got {created}"
+        # entity_registry_enabled_default is only read once, at registry
+        # creation — enabled_default must not depend on region data timing.
+        assert mqtt_selects[0].entity_registry_enabled_default is True
+        assert mqtt_selects[0].available is False
+
+    @pytest.mark.asyncio
+    async def test_no_cloud_with_existing_region_data_is_available(self):
+        from custom_components.roomba_plus import select as sel_mod
+        from custom_components.roomba_plus.select import SmartZoneSelect
+        from custom_components.roomba_plus.models import MapCapability
+
+        state = {
+            "pmaps": [{"map1": "v1"}],
+            "lastCommand": {"regions": [{"region_id": "3"}]},
+        }
+        entry = _make_config_entry(has_cloud=False)
+        entry.runtime_data.map_capability = MapCapability.SMART
+
+        roomba = _make_roomba()
+        roomba.master_state = {"state": {"reported": state}}
+        entry.runtime_data.roomba = roomba
+        entry.runtime_data.blid = "test_blid"
+        entry.runtime_data.zone_store = None
+
+        created = []
+        def sync_add(entities, **kw): created.extend(entities)
+
+        with patch.object(sel_mod, "roomba_reported_state", return_value=state):
+            with patch.object(sel_mod, "has_smart_map", return_value=True):
+                await sel_mod.async_setup_entry(MagicMock(), entry, sync_add)
+
+        mqtt_selects = [e for e in created if isinstance(e, SmartZoneSelect)]
+        assert len(mqtt_selects) == 1
+        assert mqtt_selects[0].entity_registry_enabled_default is True
+        assert mqtt_selects[0].available is True
 
     @pytest.mark.asyncio
     async def test_cloud_active_suppresses_repair_issue(self):

--- a/tests/test_sensor_cloud.py
+++ b/tests/test_sensor_cloud.py
@@ -487,8 +487,11 @@ class TestCloudHistorySensorUniqueId:
 
 
 def _rec(done="done", done_raw="done", pause_id=0, chrgs=0, evacs=0,
-         dirt=0, timestamp=1700000000, classified=None):
+         dirt=0, timestamp=None, classified=None):
     """Build a minimal raw record dict with classified_result pre-computed."""
+    if timestamp is None:
+        import datetime as _dt
+        timestamp = int(_dt.datetime.now(_dt.timezone.utc).timestamp())
     r = {
         "done":      done,
         "done_raw":  done_raw,
@@ -553,11 +556,12 @@ class TestCloudLastErrorTime:
     def test_returns_datetime_from_timestamp(self):
         import datetime
         from custom_components.roomba_plus.sensor import _raw_cloud_last_error_time
-        records = [_rec(done="stuck", pause_id=17, timestamp=1700000000)]
+        ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp()) - 3600
+        records = [_rec(done="stuck", pause_id=17, timestamp=ts)]
         result = _raw_cloud_last_error_time(records)
         assert result is not None
         assert isinstance(result, datetime.datetime)
-        assert result.year == 2023
+        assert result == datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc)
         assert result.tzinfo == datetime.timezone.utc
 
     def test_none_when_no_failed_missions(self):
@@ -573,13 +577,64 @@ class TestCloudLastErrorTime:
         import datetime
         from custom_components.roomba_plus.sensor import _raw_cloud_last_error_time
         # Records newest-first — first error timestamp wins
+        now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
         records = [
-            _rec(done="stuck", pause_id=17, timestamp=1700010000),
-            _rec(done="stuck", pause_id=18, timestamp=1700000000),
+            _rec(done="stuck", pause_id=17, timestamp=now - 3600),
+            _rec(done="stuck", pause_id=18, timestamp=now - 7200),
         ]
         result = _raw_cloud_last_error_time(records)
-        expected = datetime.datetime.fromtimestamp(1700010000, tz=datetime.timezone.utc)
+        expected = datetime.datetime.fromtimestamp(now - 3600, tz=datetime.timezone.utc)
         assert result == expected
+
+    def test_none_when_only_failed_record_is_older_than_30_days(self):
+        """event_counts_30d's error_time attribute must honour its own
+        30-day framing — `records` is a count-based API window, not itself
+        bounded to 30 days.
+        """
+        import datetime
+        from custom_components.roomba_plus.sensor import _raw_cloud_last_error_time
+        now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        stale_ts = now - 31 * 86400
+        records = [
+            _rec(done="done", timestamp=now - 3600),
+            _rec(done="stuck", pause_id=17, timestamp=stale_ts),
+        ]
+        assert _raw_cloud_last_error_time(records) is None
+
+    def test_state_code_none_when_only_failed_record_is_older_than_30_days(self):
+        """event_counts_30d's headline STATE must agree with its error_time
+        attribute: a failure older than the 30-day framing is not surfaced
+        as a code either."""
+        import datetime
+        from custom_components.roomba_plus.sensor import _raw_cloud_last_error_code
+        now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        stale_ts = now - 31 * 86400
+        records = [
+            _rec(done="done", timestamp=now - 3600),
+            _rec(done="stuck", pause_id=17, timestamp=stale_ts),
+        ]
+        assert _raw_cloud_last_error_code(records) is None
+
+    def test_state_code_and_attrs_recent_error_agree(self):
+        """Within the 30-day window the newest failed record drives state,
+        timestamp and attrs identically (shared selection)."""
+        import datetime
+        from custom_components.roomba_plus.sensor import (
+            _raw_cloud_last_error_attrs,
+            _raw_cloud_last_error_code,
+            _raw_cloud_last_error_time,
+        )
+        now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        recent = now - 3600
+        records = [
+            _rec(done="done", timestamp=now - 7200),
+            _rec(done="stuck", pause_id=17, timestamp=recent),
+        ]
+        assert _raw_cloud_last_error_code(records) == 17
+        assert _raw_cloud_last_error_time(records) is not None
+        attrs = _raw_cloud_last_error_attrs(records)
+        assert attrs.get("error_code") == 17
+
 
 
 class TestCloudLastErrorAttrs:
@@ -604,6 +659,13 @@ class TestCloudLastErrorAttrs:
         records = [_rec(done="stuck", pause_id=0)]
         attrs = _raw_cloud_last_error_attrs(records)
         assert attrs.get("error_code") is None
+
+    def test_empty_when_only_failed_record_is_older_than_30_days(self):
+        import datetime
+        from custom_components.roomba_plus.sensor import _raw_cloud_last_error_attrs
+        now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        records = [_rec(done="stuck", pause_id=17, timestamp=now - 31 * 86400)]
+        assert _raw_cloud_last_error_attrs(records) == {}
 
 
 # ============================================================================
@@ -733,15 +795,26 @@ class TestCleaningPerformanceSensor:
 
     def test_returns_completion_rate_with_records(self):
         records = [
-            {"done": "done", "sqft": 300, "runM": 40},
-            {"done": "done", "sqft": 280, "runM": 38},
-            {"done": "hmPostMsn"},
+            {"done": "done", "classified_result": "completed", "sqft": 300, "runM": 40},
+            {"done": "done", "classified_result": "completed", "sqft": 280, "runM": 38},
+            {"done": "hmPostMsn", "classified_result": "unknown"},
         ]
         s = _make_sensor_v270_consolidated_sensors(RoombaCleaningPerformanceSensor, records=records)
         val = s.native_value
         assert val is not None
         assert isinstance(val, float)
         assert 0 <= val <= 100
+
+    def test_counts_done_ok_as_completed(self):
+        """Cloud API reports some completions as done="ok" rather than "done" —
+        classify_mission_result already maps both to "completed"; the sensor
+        must use that classification, not a raw done == "done" check.
+        """
+        records = [_rec(done="ok"), _rec(done="ok"), _rec(done="hmPostMsn", classified="unknown")]
+        s = _make_sensor_v270_consolidated_sensors(RoombaCleaningPerformanceSensor, records=records)
+        val = s.native_value
+        assert val is not None
+        assert val == round(2 / 3 * 100, 1)
 
     def test_attributes_include_trend(self):
         # Need ≥6 records for trend to be non-unknown

--- a/tests/test_sensor_core.py
+++ b/tests/test_sensor_core.py
@@ -57,6 +57,14 @@ class TestAreaSensorsCanBeConverted:
 
         assert len(found) >= 2
 
+    def test_total_cleaned_area_declares_total_increasing(self):
+        from homeassistant.components.sensor import SensorStateClass
+
+        from custom_components.roomba_plus.sensor_core import SENSORS
+
+        desc = next(d for d in SENSORS if d.key == "total_cleaned_area")
+        assert desc.state_class == SensorStateClass.TOTAL_INCREASING
+
 
 class TestCountsAreNotMeasurements:
     """@chairstacker's graph showed `9.89725` for `clean_streak` — a
@@ -599,6 +607,33 @@ class TestClassicStatusReportsTheSameTwoStates:
         assert self._status(
             "run", cycle="clean", last_ts=time.time() - 300
         ) == "running"
+
+
+class TestErrorValueReturnsRealNone:
+    """HA renders the literal string "None" as a displayed state instead of
+    the entity going unavailable/unknown — _error_value must return the
+    Python object None, never the string "None".
+    """
+
+    @staticmethod
+    def _error(cycle, phase, error=0, error_message=None):
+        from custom_components.roomba_plus.sensor_helpers import _error_value
+
+        entity = MagicMock()
+        entity.clean_mission_status = {"cycle": cycle, "phase": phase, "error": error}
+        entity.vacuum.error_message = error_message
+        return _error_value(entity)
+
+    def test_suppressed_stale_error_is_none(self):
+        result = self._error("none", "charge", error=17)
+        assert result is None
+        assert result != "None"
+
+    def test_no_error_fallback_is_none(self):
+        result = self._error("clean", "run", error=0, error_message=None)
+        assert result is None
+        assert result != "None"
+
 class _FakeEntity:
     def __init__(self, vacuum_state=None, clean_mission_status=None):
         self.vacuum_state = vacuum_state or {}

--- a/tests/test_sensor_diagnostics.py
+++ b/tests/test_sensor_diagnostics.py
@@ -158,6 +158,26 @@ class TestResetDiagnosticsSensor:
         })
         assert "oom_resets" not in sensor.extra_state_attributes
 
+    def test_translation_key_is_summary_noun_phrase(self):
+        """The prior key ("reset_diagnostics") resolved to an imperative-
+        looking display name for a passive counter sensor.
+        """
+        roomba = MagicMock()
+        roomba.master_state = {"state": {"reported": {}}}
+        sensor = RoombaResetDiagnosticsSensor(roomba, "test_blid")
+        assert sensor.translation_key == "reset_diagnostics_summary"
+
+    def test_unique_id_and_entity_id_construction_unchanged(self):
+        """The translation_key rename affects display name only; unique_id
+        (and thus the initial entity_id) must stay byte-for-byte identical
+        so existing entity registrations are not broken.
+        """
+        roomba = MagicMock()
+        roomba.master_state = {"state": {"reported": {}}}
+        sensor = RoombaResetDiagnosticsSensor(roomba, "test_blid")
+        assert sensor.unique_id == "roomba_plus_test_blid_reset_diagnostics"
+        assert sensor.suggested_object_id == "reset_diagnostics"
+
 
 def _make_health_trend_sensor(rps):
     """Return a RoombaHealthScoreTrendSensor with the given robot_profile_store

--- a/tests/test_sensor_prime.py
+++ b/tests/test_sensor_prime.py
@@ -644,17 +644,17 @@ class TestPrimeErrorSensor:
         from a finished mission, robot back on the dock."""
         sensor = self._entity(cycle="none", phase="charge", error=671)
 
-        assert sensor.native_value == "None"
+        assert sensor.native_value is None
 
     def test_suppresses_stale_error_when_idle_too(self):
         sensor = self._entity(cycle="none", phase="idle", error=671)
 
-        assert sensor.native_value == "None"
+        assert sensor.native_value is None
 
     def test_no_error_during_a_mission_reports_none_label(self):
         sensor = self._entity(cycle="clean", phase="run", error=0)
 
-        assert sensor.native_value == "None"
+        assert sensor.native_value is None
 
     def test_exposes_readiness_fields_as_attributes(self):
         """A readiness-based START REFUSAL leaves `error` at 0 and puts

--- a/tests/test_sensor_rooms.py
+++ b/tests/test_sensor_rooms.py
@@ -1019,3 +1019,34 @@ class TestCurrentRoomSaysHowItKnows:
         ).read_text(encoding="utf-8")
 
         assert '"estimate" if current_room is not None else "mission_timer"' in source
+
+
+class TestRoombaEdgeCoverageSensorRetainsLastValidRatio:
+    @staticmethod
+    def _sensor(grid_store):
+        from custom_components.roomba_plus.sensor_rooms import (
+            RoombaEdgeCoverageSensor,
+        )
+
+        sensor = object.__new__(RoombaEdgeCoverageSensor)
+        entry = _make_entry()
+        entry.runtime_data.grid_store = grid_store
+        entry.runtime_data.robot_profile_store = None
+        sensor._config_entry = entry
+        return sensor
+
+    def test_native_value_retains_ratio_while_attrs_reflect_current_grid(self):
+        from custom_components.roomba_plus.grid_store import GridStore
+
+        gs = GridStore()
+        for gx in range(10):
+            for gy in range(10):
+                gs._cells[(gx, gy)] = 0.5
+        valid = gs.edge_coverage_ratio()
+        assert valid is not None
+
+        gs._cells = {(0, 0): 0.5}
+
+        sensor = self._sensor(gs)
+        assert sensor.native_value == valid
+        assert sensor.extra_state_attributes["total_cells"] == 1


### PR DESCRIPTION
## What

Resolves the issues from a live-instance investigation report (2026-08-29), re-verified against current v4.0.0b3 source before fixing. Base: upstream alpha/v4.0.0-for-v4-protocoll-robots (88a03a4, v4.0.0b3), via fork branch mdarocha/fix/live-investigation-2026-09.

## Mission lifecycle
- Terminal mission record fields (duration, initiator, started/ended timestamps, id, result) are frozen on first write. Later updates for the same mission merge additive fields only, and only when they arrive within the MQTT re-delivery window; a write arriving materially later is a real 980/900-series multi-recharge segment and still gets appended as its own segment. This stops a completed mission's duration and initiator from silently changing after the fact.
- The last-30-days mission counter now counts distinct missions rather than every stored record, so duplicate/segment records can't inflate it.
- A robot's phase flipping back to "running" minutes or hours after a mission already completed (a stale MQTT replay) no longer re-opens tracking for that mission, unless it's genuinely far enough later to be a new recharge segment.
- Cloud data reconciliation keeps correcting the known firmware bug where local timestamps degrade to zero duration, while no longer letting a stale cloud re-delivery rewrite an already-settled mission's timing. Cloud-sourced result corrections (e.g. reclassifying a stuck mission as a battery error) still apply, but only once per mission.
- A mission that ends "stuck" with no specific error code now still gets its last-known-error info restored after a Home Assistant restart.

## Sensors
- The lifetime energy sensor now floors at a persisted high-water mark advanced at mission end, so it can no longer report a lower value than before (it previously could, violating its own always-increasing contract).
- The lifetime cleaned-area sensor is now correctly marked as an always-increasing statistic.
- The presence/utilisation percentage sensor can no longer read above 100%.
- The cleaning-performance sensor's completion rate now agrees with the same classification the archive uses, instead of undercounting certain completed missions.
- The 30-day event-count sensor's error state, code, timestamp, and label attributes now all honor the same 30-day window, instead of the state occasionally showing a month-old error the attributes had already excluded.
- Error sensors (on both the classic and newer robot generations) report the correct "no error" state instead of the literal text "None".
- The diagnostics-reset sensor's translation key was renamed from an imperative-sounding name to a plain noun phrase, in all 8 shipped languages; its entity id is unchanged.

## Maps
- A completed mission now always refreshes the route, rooms, and coverage map images exactly once, even for missions with no pose data, instead of the refresh only firing for some missions. Verified pose-reporting robots are unaffected: they still feed the coverage grid and receive the same refresh signal as before.
- The coverage-ratio sensor now retains its last valid reading across sparse or empty missions instead of dropping to unavailable, while its own cell-count/geometry attributes keep reflecting the current mission honestly.

## Platform / UX
- Device-tracker state labels now cover all 8 shipped languages instead of falling back to English for 6 of them.
- Internal firmware-only favourites are no longer exposed as user-facing buttons.
- The local smart-zone selector stays enabled instead of getting permanently disabled the first time it has no zone data yet; its availability now correctly reflects whether zone data exists.

## Icons
- Icon registry coverage completed across every entity platform, including new sections for device tracker, calendar, and todo entities. A new test enforces this coverage going forward.

## Already fixed on v4.0.0b3, verified but not re-touched
- The cloud mission-timeline fetch already replaced its old hard give-up with bounded retries, and later refreshes still pick up delayed data.
- Room-cleaning history already merges newly-cleaned rooms correctly.
- The options-flow menu row that used to render blank is already fixed.
- The area sensor's old 7.3x scale bug is already gone from the codebase.

## Explicitly out of scope
- A cross-integration entity-naming quirk from a third-party integration (Home Keeper), not something this integration controls.
- A documentation gap around two similarly-named entities that measure different things by design — not a behavioral bug.

## Verification

Full test suite: 6143 passed, 4 skipped, 0 failed. Regression tests reproduce the exact reported symptoms (the mission duration/initiator rewrite sequence, the energy sensor decreasing, the utilisation percentage exceeding 100%, the stale error surfacing past 30 days, images not refreshing after a pose-less mission, and the multi-recharge segment / cloud-correction edge cases found during review).
